### PR TITLE
[GP-248] Field statici con contenuto dinamico

### DIFF
--- a/govpay-web-console/src/main/java/it/govpay/web/rs/dars/anagrafica/anagrafica/AnagraficaHandler.java
+++ b/govpay-web-console/src/main/java/it/govpay/web/rs/dars/anagrafica/anagrafica/AnagraficaHandler.java
@@ -246,7 +246,7 @@ public class AnagraficaHandler {
 
 			// codunivoco (hidden!)
 			String codUnivocoLabel = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + "." + this.nomeAnagrafica + ".codUnivoco.label");
-			InputText codUnivoco = new InputText(codUnivocoId, codUnivocoLabel, null, true, true,true, 1, 35);
+			InputText codUnivoco = new InputText(codUnivocoId, codUnivocoLabel, null, false, true,true, 1, 35);
 			//			codUnivoco.setValidation(null, Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + "." + this.nomeAnagrafica + ".codUnivoco.errorMessage"));
 			mappaCreazione.put(codUnivocoId, codUnivoco);
 

--- a/govpay-web-console/src/main/java/it/govpay/web/rs/dars/anagrafica/tributi/TributiHandler.java
+++ b/govpay-web-console/src/main/java/it/govpay/web/rs/dars/anagrafica/tributi/TributiHandler.java
@@ -107,7 +107,12 @@ public class TributiHandler extends BaseDarsHandler<Tributo> implements IDarsHan
 
 			String idDominioId = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio+ ".idDominio.id");
 			this.idDominio = this.getParameter(uriInfo, idDominioId, Long.class);
+
 			filter.setIdDominio(this.idDominio);
+			
+			String codTributoId = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + ".codTributo.id");
+			String codTributo = this.getParameter(uriInfo, codTributoId, String.class);
+			filter.setCodTributo(codTributo); 
 
 			long count = tributiBD.count(filter);
 
@@ -140,14 +145,19 @@ public class TributiHandler extends BaseDarsHandler<Tributo> implements IDarsHan
 
 	@Override
 	public InfoForm getInfoRicerca(UriInfo uriInfo, BasicBD bd) throws ConsoleException {
-		URI ricerca = this.getUriRicerca(uriInfo, bd);
+		String idDominioId = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + ".idDominio.id");
+		URI ricerca =  null;
+		try{
+			ricerca =  BaseRsService.checkDarsURI(uriInfo).path(this.pathServizio).queryParam(idDominioId, this.idDominio).build();
+		}catch(Exception e ){
+			throw new ConsoleException(e);
+		}
 		InfoForm infoRicerca = new InfoForm(ricerca);
 
 		String codTributoId = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + ".codTributo.id");
 
 		if(infoRicercaMap == null){
 			this.initInfoRicerca(uriInfo, bd);
-
 		}
 
 		Sezione sezioneRoot = infoRicerca.getSezioneRoot();
@@ -155,6 +165,11 @@ public class TributiHandler extends BaseDarsHandler<Tributo> implements IDarsHan
 		InputText codTributo = (InputText) infoRicercaMap.get(codTributoId);
 		codTributo.setDefaultValue(null);
 		sezioneRoot.addField(codTributo);
+
+//		InputNumber idDominio = (InputNumber) infoRicercaMap.get(idDominioId);
+//		idDominio.setDefaultValue(this.idDominio);
+//		sezioneRoot.addField(idDominio);
+
 
 		return infoRicerca;
 	}
@@ -164,11 +179,16 @@ public class TributiHandler extends BaseDarsHandler<Tributo> implements IDarsHan
 			infoRicercaMap = new HashMap<String, ParamField<?>>();
 
 			String codTributoId = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + ".codTributo.id");
+//			String idDominioId = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + ".idDominio.id");
 
 			// codTributo
 			String codTributoLabel = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + ".codTributo.label");
 			InputText codTributo = new InputText(codTributoId, codTributoLabel, null, false, false, true, 1, 255);
 			infoRicercaMap.put(codTributoId, codTributo);
+
+			// idDominio
+//			InputNumber idDominio = new InputNumber(idDominioId, null, null, true, true, false, 1, 255);
+//			infoRicercaMap.put(idDominioId, idDominio);
 		}
 	}
 

--- a/govpay-web-console/src/main/java/it/govpay/web/rs/dars/anagrafica/uo/UnitaOperativeHandler.java
+++ b/govpay-web-console/src/main/java/it/govpay/web/rs/dars/anagrafica/uo/UnitaOperativeHandler.java
@@ -142,7 +142,13 @@ public class UnitaOperativeHandler extends BaseDarsHandler<UnitaOperativa> imple
 
 	@Override
 	public InfoForm getInfoRicerca(UriInfo uriInfo, BasicBD bd) throws ConsoleException {
-		URI ricerca = this.getUriRicerca(uriInfo, bd);
+		String idDominioId = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + ".idDominio.id");
+		URI ricerca =  null;
+		try{
+			ricerca =  BaseRsService.checkDarsURI(uriInfo).path(this.pathServizio).queryParam(idDominioId, this.idDominio).build();
+		}catch(Exception e ){
+			throw new ConsoleException(e);
+		}
 		InfoForm infoRicerca = new InfoForm(ricerca);
 
 		String codUoId = Utils.getInstance().getMessageFromResourceBundle(this.nomeServizio + ".codUo.id");

--- a/govpay-web-console/src/main/webapp/elements/elements.html
+++ b/govpay-web-console/src/main/webapp/elements/elements.html
@@ -28318,7 +28318,7 @@ It will also ensure that focus remains in the dialog.
       }
 
       .self-end {
-        width: 100%;
+          /*width: 100%; */
         @apply(--layout-self-end);
       }
 
@@ -28397,6 +28397,10 @@ It will also ensure that focus remains in the dialog.
         height: 40px;
         color: #fff;
       }
+
+      paper-tabs {
+        --paper-tabs-selection-bar: { height: 4px; };
+      }
     </style>
     
     <paper-scroll-header-panel class="main" main="" fixed="">
@@ -28408,7 +28412,7 @@ It will also ensure that focus remains in the dialog.
         <div class="space"></div>
         
         <link-user-action user="[[user]]"></link-user-action>
-        <paper-tabs selected="{{selectedTab}}" class="bottom self-end">
+        <paper-tabs selected="{{selectedTab}}" class="bottom self-end" on-iron-select="cambiaTab">
           <paper-tab class="tabTitle">Dettaglio</paper-tab>
           <template is="dom-repeat" items="[[obj.elementiCorrelati]]">
             <paper-tab class="tabTitle">[[item.etichetta]]</paper-tab>
@@ -28435,7 +28439,7 @@ It will also ensure that focus remains in the dialog.
           </div>
           <template is="dom-repeat" items="[[obj.elementiCorrelati]]">
             <div class="correlati">
-              <link-search-view title="[[item.etichetta]]" hide-toolbar="" resource="[[item.uri]]"></link-search-view>
+              <link-search-view indice="[[index]]" title="[[item.etichetta]]" hide-toolbar="" resource="[[item.uri]]"></link-search-view>
             </div>
           </template>
         </iron-pages>
@@ -28616,6 +28620,21 @@ It will also ensure that focus remains in the dialog.
 
       saved: function(event){
         this.set('obj', event.detail);
+      },
+
+      cambiaTab: function (event) {
+
+        console.log(this.selectedTab);
+
+        if(this.selectedTab > 0) {
+          var ec = this.querySelectorAll('link-search-view');
+          for (var k = 0; k < ec.length; k++) {
+            var obj = ec[k];
+            console.log(obj.indice);
+            if(obj.indice == this.selectedTab - 1)
+              obj.refresh();
+          }
+        }
       }
     });
   })();
@@ -29208,7 +29227,8 @@ event and do your own custom submission:
         }
         this.$.searchResource.url = this.searchUrl;
         if (query.length>0){
-          this.$.searchResource.url += '?'+query.join('&');
+          var pp = this.$.searchResource.url.indexOf('?') > -1 ? '&' : '?';
+          this.$.searchResource.url += pp +query.join('&');
         }
         app.showSpinner();
         this.$.searchResource.generateRequest();


### PR DESCRIPTION
E' stato modificata la gestione degli elementi correlati di un dettaglio,
ora quando si seleziona il tab contenente l'elemento correlato vengono ricaricati sia l'elenco dei risultati sia la form di creazione/edit.

Nella sezione dei domini, per esempio, ora la form dei tributi presenta gli eventuali Iban appena creati.
E' stata modificata la visualizzazione delle label dei tab presenti nella pagina di dettaglio, ora sono allineate a sinistra.
Infine e' stato aumentato lo spessore dell'evidenziatura del tab selezionato.