### PR TITLE
Corretto passaggio dell'argomento

### DIFF
--- a/govpay-core/src/main/java/it/govpay/core/utils/IuvUtils.java
+++ b/govpay-core/src/main/java/it/govpay/core/utils/IuvUtils.java
@@ -75,7 +75,7 @@ public class IuvUtils {
 		iuvGenerato.setCodDominio(dominio.getCodDominio());
 		iuvGenerato.setCodVersamentoEnte(iuv.getCodVersamentoEnte());
 		iuvGenerato.setIuv(iuv.getIuv());
-		iuvGenerato.setBarCode(buildBarCode(dominio.getCodDominio(), iuv.getApplicationCode(), iuv.getIuv(), importoTotale).getBytes());
+		iuvGenerato.setBarCode(buildBarCode(dominio.getGln(), iuv.getApplicationCode(), iuv.getIuv(), importoTotale).getBytes());
 		switch (GovpayConfig.getInstance().getVersioneAvviso()) {
 		case v001:
 			iuvGenerato.setQrCode(buildQrCode001(dominio.getCodDominio(), iuv.getApplicationCode(), iuv.getIuv(), importoTotale));


### PR DESCRIPTION
buildBarCode ha come primo parametro il codice GLN dell'ente creditore, non il codice dominio.