### PR TITLE
618 autenticazione client tramite header http

### DIFF
--- a/integration-test/src/test/java/test/api/backoffice/v1/applicazioni/put/applicazioni-put-sintassi.feature
+++ b/integration-test/src/test/java/test/api/backoffice/v1/applicazioni/put/applicazioni-put-sintassi.feature
@@ -68,6 +68,8 @@ Examples:
 | servizioIntegrazione | { versioneApi: 'REST v1', url: 'http://prova.it', auth: { tipo: 'Server', ksLocation: '/tmp/keystore.jks', ksPassword: 'kspwd', tsLocation: '/tmp/truststore.jks', tsPassword: 'tspwd', tsType: 'XXX', sslType: 'TLSv1.2'	} } |  'tsType' |
 | servizioIntegrazione | { versioneApi: 'REST v1', url: 'http://prova.it', auth: { tipo: 'Server', ksLocation: '/tmp/keystore.jks', ksPassword: 'kspwd', tsLocation: '/tmp/truststore.jks', tsPassword: 'tspwd', tsType: 'JKS', sslType: null	} } |  'sslType' |
 | servizioIntegrazione | { versioneApi: 'REST v1', url: 'http://prova.it', auth: { tipo: 'Server', ksLocation: '/tmp/keystore.jks', ksPassword: 'kspwd', tsLocation: '/tmp/truststore.jks', tsPassword: 'tspwd', tsType: 'JKS', sslType: 'XXX'	} } |  'sslType' |
+| servizioIntegrazione | { versioneApi: 'REST v1', url: 'http://prova.it', auth: { headerName: null, headerValue: 'govpay' } } | 'headerName' |
+| servizioIntegrazione | { versioneApi: 'REST v1', url: 'http://prova.it', auth: { headerName: 'X-GOVPAY-AUTH', headerValue: null } } | 'headerValue' |
 | abilitato | null | 'abilitato' |
 | abilitato | 'sss' | 'abilitato' |
 | apiPagamenti | null | 'apiPagamenti' |

--- a/integration-test/src/test/java/test/api/backoffice/v1/applicazioni/put/applicazioni-put.feature
+++ b/integration-test/src/test/java/test/api/backoffice/v1/applicazioni/put/applicazioni-put.feature
@@ -68,6 +68,8 @@ Examples:
 | servizioIntegrazione | { versioneApi: 'REST v2', url: 'http://prova.it', auth: { username: 'usr', password: 'pwd' } } |
 | servizioIntegrazione | { versioneApi: 'REST v2', url: 'http://prova.it', auth: { tipo: 'Client', ksLocation: '/tmp/keystore.jks', ksPassword: 'kspwd', tsLocation: '/tmp/truststore.jks', tsPassword: 'tspwd', tsType: 'JKS', sslType: 'TLSv1.2' , ksType: 'JKS', ksPKeyPasswd: 'ksPKeyPasswd'	} } | 
 | servizioIntegrazione | { versioneApi: 'REST v2', url: 'http://prova.it', auth: { tipo: 'Server', tsLocation: '/tmp/truststore.jks', tsPassword: 'tspwd', tsType: 'JKS', sslType: 'TLSv1.2'	} } |
+| servizioIntegrazione | { versioneApi: 'REST v1', url: 'http://prova.it', auth: { headerName: 'X-GOVPAY-AUTH', headerValue: 'govpay' } } |
+| servizioIntegrazione | { versioneApi: 'REST v2', url: 'http://prova.it', auth: { headerName: 'X-GOVPAY-AUTH', headerValue: 'govpay' } } |
 | abilitato | false | 
 | abilitato | true |
 | apiPagamenti | false | 

--- a/integration-test/src/test/java/test/api/backoffice/v1/intermediari/put/intermediari-put-sintassi.feature
+++ b/integration-test/src/test/java/test/api/backoffice/v1/intermediari/put/intermediari-put-sintassi.feature
@@ -10,6 +10,7 @@ Background:
 * def intermediarioBasicAuth = read('classpath:test/api/backoffice/v1/intermediari/put/msg/intermediarioBasicAuth.json')
 * def intermediarioClientAuth = read('classpath:test/api/backoffice/v1/intermediari/put/msg/intermediarioClientAuth.json')
 * def intermediarioServerAuth = read('classpath:test/api/backoffice/v1/intermediari/put/msg/intermediarioServerAuth.json')
+* def intermediarioHeaderAuth = read('classpath:test/api/backoffice/v1/intermediari/put/msg/intermediarioHeaderAuth.json')
 * def loremIpsum = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus non neque vestibulum, porta eros quis, fringilla enim. Nam sit amet justo sagittis, pretium urna et, convallis nisl. Proin fringilla consequat ex quis pharetra. Nam laoreet dignissim leo. Ut pulvinar odio et egestas placerat. Quisque tincidunt egestas orci, feugiat lobortis nisi tempor id. Donec aliquet sed massa at congue. Sed dictum, elit id molestie ornare, nibh augue facilisis ex, in molestie metus enim finibus arcu. Donec non elit dictum, dignissim dui sed, facilisis enim. Suspendisse nec cursus nisi. Ut turpis justo, fermentum vitae odio et, hendrerit sodales tortor. Aliquam varius facilisis nulla vitae hendrerit. In cursus et lacus vel consectetur.'
 
 Scenario Outline: <field> non valida
@@ -116,4 +117,29 @@ Examples:
 | sslType | intermediarioServerAuth.servizioPagoPa.auth.sslType | 'XXX' |  'sslType' |
 | subscriptionKey | intermediarioServerAuth.servizioPagoPa.subscriptionKey | '' |  'subscriptionKey' |
 | subscriptionKey | intermediarioServerAuth.servizioPagoPa.subscriptionKey | loremIpsum |  'subscriptionKey' |
+
+
+Scenario Outline: <field> non valida
+
+* set <fieldRequest> = <fieldValue>
+
+Given url backofficeBaseurl
+And path 'intermediari', idIntermediario
+And headers basicAutenticationHeader
+And request intermediarioHeaderAuth
+When method put
+Then status 400
+
+* match response == { categoria: 'RICHIESTA', codice: 'SINTASSI', descrizione: 'Richiesta non valida', dettaglio: '#notnull' }
+* match response.dettaglio contains <fieldResponse>
+
+Examples:
+| field | fieldRequest | fieldValue | fieldResponse |
+| headerName | intermediarioHeaderAuth.servizioPagoPa.auth.headerName | null |  'headerName' |
+| headerValue | intermediarioHeaderAuth.servizioPagoPa.auth.headerValue | null |  'headerValue' |
+| subscriptionKey | intermediarioHeaderAuth.servizioPagoPa.subscriptionKey | '' |  'subscriptionKey' |
+| subscriptionKey | intermediarioHeaderAuth.servizioPagoPa.subscriptionKey | loremIpsum |  'subscriptionKey' |
+| denominazione | intermediarioHeaderAuth.denominazione | null |  'denominazione' |
+
+
 

--- a/integration-test/src/test/java/test/api/backoffice/v1/intermediari/put/intermediari-put.feature
+++ b/integration-test/src/test/java/test/api/backoffice/v1/intermediari/put/intermediari-put.feature
@@ -10,6 +10,7 @@ Background:
 * def intermediarioBasicAuth = read('classpath:test/api/backoffice/v1/intermediari/put/msg/intermediarioBasicAuth.json')
 * def intermediarioServerAuth = read('classpath:test/api/backoffice/v1/intermediari/put/msg/intermediarioServerAuth.json')
 * def intermediarioClientAuth = read('classpath:test/api/backoffice/v1/intermediari/put/msg/intermediarioClientAuth.json')
+* def intermediarioHeaderAuth = read('classpath:test/api/backoffice/v1/intermediari/put/msg/intermediarioHeaderAuth.json')
 
 Scenario: Configurazione intermediario senza autenticazione verso pagoPA
 
@@ -109,4 +110,24 @@ And headers basicAutenticationHeader
 When method get
 Then status 200
 And match response == intermediario
+
+Scenario: Configurazione intermediario con autenticazione header verso pagoPA
+
+Given url backofficeBaseurl
+And path 'intermediari', idIntermediario
+And headers basicAutenticationHeader
+And request intermediarioHeaderAuth
+When method put
+Then assert responseStatus == 200 || responseStatus == 201
+
+* set intermediarioHeaderAuth.idIntermediario = idIntermediario
+* set intermediarioHeaderAuth.stazioni = '#ignore'
+
+Given url backofficeBaseurl
+And path 'intermediari', idIntermediario
+And headers basicAutenticationHeader
+When method get
+Then status 200
+And match response == intermediarioHeaderAuth
+
 

--- a/integration-test/src/test/java/test/api/backoffice/v1/intermediari/put/msg/intermediarioHeaderAuth.json
+++ b/integration-test/src/test/java/test/api/backoffice/v1/intermediari/put/msg/intermediarioHeaderAuth.json
@@ -1,0 +1,12 @@
+{
+	"denominazione": "Soggetto Intermediario",
+	"principalPagoPa": '#(ndpsym_user)',
+	"servizioPagoPa": {
+		"urlRPT": '#(ndpsym_url + "/pagopa/PagamentiTelematiciRPTservice")',
+		"auth": {
+			"headerName": "X-GOVPAY-AUTH",
+			"headerValue": "govpay"
+		}
+	},
+	"abilitato": true
+}

--- a/integration-test/src/test/java/test/api/ente/v2/ricevute/put/ricevute-put.feature
+++ b/integration-test/src/test/java/test/api/ente/v2/ricevute/put/ricevute-put.feature
@@ -322,6 +322,137 @@ And match response.risultati[1] ==
 """
 And match response.risultati[1].parametriRichiesta.url == ente_api_url + "/v1/avvisi/"+ idDominio + "/" + numeroAvviso
 
+@test-auth
+Scenario: Verifica tutti gli eventi di un Pagamento eseguito di un dovuto precaricato non scaduto verso API Ente con autenticazione header
+
+* def headerPrincipal = 'govpay'
+* def applicazione = read('classpath:configurazione/v1/msg/applicazione.json')
+* set applicazione.servizioIntegrazione.versioneApi = 'REST v2'
+* set applicazione.servizioIntegrazione.url = ente_api_url + '/v1'
+* set applicazione.servizioIntegrazione.auth.headerName = 'X-GOVPAY-AUTH'
+* set applicazione.servizioIntegrazione.auth.headerValue = headerPrincipal
 
 
+# "url": '#(ente_api_url + "/v1")',
 
+Given url backofficeBaseurl
+And path 'applicazioni', idA2A
+And headers gpAdminBasicAutenticationHeader
+And request applicazione
+When method put
+Then assert responseStatus == 200 || responseStatus == 201
+
+* call read('classpath:configurazione/v1/operazioni-resetCache.feature')
+
+* def idPendenza = getCurrentTimeMillis()
+* def pendenzaPut = read('classpath:test/api/pendenza/v3/pendenze/put/msg/pendenza-put_monovoce_riferimento.json')
+
+Given url backofficeBaseurl
+And path '/pendenze', idA2A, idPendenza
+And headers idA2ABasicAutenticationHeader
+And request pendenzaPut
+When method put
+Then status 201
+
+* def numeroAvviso = response.numeroAvviso
+* def iuv = getIuvFromNumeroAvviso(numeroAvviso)
+
+* def importo = pendenzaPut.importo
+
+* def esitoAttivaRPT = read('classpath:test/workflow/modello3/v1/msg/attiva-response-ok.json')
+* def esitoVerificaRPT = read('classpath:test/workflow/modello3/v1/msg/verifica-response-ok.json')
+
+# Verifico il pagamento
+
+* call read('classpath:utils/psp-verifica-rpt.feature')
+* match response.esitoVerificaRPT == esitoVerificaRPT
+* def ccp = response.ccp
+
+# Attivo il pagamento 
+
+* def tipoRicevuta = "R01"
+* call read('classpath:utils/psp-attiva-rpt.feature')
+* match response.dati == esitoAttivaRPT
+
+# Verifico la notifica di terminazione
+
+* call read('classpath:utils/pa-notifica-terminazione.feature')
+* match response == read('classpath:test/api/ente/v2/ricevute/put/msg/transazione-get-singolo_eseguito_ente.json')
+
+# Verifico lo stato della pendenza
+
+* call read('classpath:utils/api/v1/backoffice/pendenza-get-dettaglio.feature')
+* match response.stato == 'ESEGUITA'
+* match response.dataPagamento == '#regex \\d\\d\\d\\d-\\d\\d-\\d\\d'
+* match response.voci[0].stato == 'Eseguito'
+* match response.rpp == '#[1]'
+* match response.rpp[0].stato == 'RT_ACCETTATA_PA'
+* match response.rpp[0].rt == '#notnull'
+
+* def backofficeBaseurl = getGovPayApiBaseUrl({api: 'backoffice', versione: 'v1', autenticazione: 'basic'})
+
+* call sleep(200)
+
+Given url backofficeBaseurl
+And path '/eventi'
+And param idDominio = idDominio
+And param iuv = iuv
+And param componente = 'API_ENTE'
+# And param tipoEvento = 'nodoInviaRPT'
+And param messaggi = true
+And headers gpAdminBasicAutenticationHeader
+When method get
+Then status 200
+And match response == 
+"""
+{
+	numRisultati: 1,
+	numPagine: '#number',
+	risultatiPerPagina: 25,
+	pagina: 1,
+	prossimiRisultati: '#ignore',
+	risultati: '#[1]'
+}
+"""
+
+# Notifica Ricevuta
+
+And match response.risultati[0] ==
+"""
+{  
+	"id": "#notnull",
+	"idDominio":"#(idDominio)",
+	"iuv":"#(iuv)",
+	"ccp":"#(''+ccp)",
+	"idA2A": "#(idA2A)",
+	"idPendenza": "#(''+idPendenza)",
+	"idPagamento": "#notnull",
+	"componente": "API_ENTE",
+	"categoriaEvento": "INTERFACCIA",
+	"ruolo": "CLIENT",
+	"tipoEvento": "notificaRicevuta",
+	"sottotipoEvento": "##null",
+	"esito": "OK",
+	"sottotipoEsito": "200",
+	"dettaglioEsito": "##string",
+	"dataEvento": "#notnull",
+	"durataEvento": "#notnull",
+	"clusterId" : "#notnull",
+	"transactionId" : "#notnull",
+	"parametriRichiesta": {
+		"dataOraRichiesta":"#regex \\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d",
+		"url": "#notnull",
+		"method": "PUT",
+		"headers": "#array",
+		"payload": "#ignore",
+		"principal": "#(headerPrincipal)"
+	},
+	"parametriRisposta": {
+		"dataOraRisposta":"#regex \\d\\d\\d\\d-\\d\\d-\\d\\dT\\d\\d:\\d\\d:\\d\\d\\.\\d\\d\\d",
+		"status": 200,
+		"headers": "#array",
+		"payload": "#ignore"
+	}
+}
+"""
+And match response.risultati[0].parametriRichiesta.url == ente_api_url + "/v1/ricevute/"+ idDominio + "/" + iuv +"/"+ ccp

--- a/jars/core/src/main/java/it/govpay/core/dao/operazioni/OperazioniDAO.java
+++ b/jars/core/src/main/java/it/govpay/core/dao/operazioni/OperazioniDAO.java
@@ -35,7 +35,7 @@ public class OperazioniDAO extends BaseDAO{
 	public final static String ELABORAZIONE_RICONCILIAZIONI = "elaborazioneRiconciliazioni";
 	public final static String CHIUSURA_RPT_SCADUTE = "chiusuraRptScadute";
 
-	public LeggiOperazioneDTOResponse eseguiOperazione(LeggiOperazioneDTO leggiOperazioneDTO) throws ServiceException, OperazioneNonTrovataException, NotAuthorizedException, NotAuthenticatedException{
+	public LeggiOperazioneDTOResponse eseguiOperazione(LeggiOperazioneDTO leggiOperazioneDTO) throws OperazioneNonTrovataException{
 		LeggiOperazioneDTOResponse response = new LeggiOperazioneDTOResponse();
 		
 		try {
@@ -57,10 +57,8 @@ public class OperazioniDAO extends BaseDAO{
 				esitoOperazione = it.govpay.core.business.Operazioni.spedizionePromemoria(ctx);
 			} else if(leggiOperazioneDTO.getIdOperazione().equals(GESTIONE_PROMEMORIA)){
 				esitoOperazione = it.govpay.core.business.Operazioni.gestionePromemoria(ctx);
-			} else if(leggiOperazioneDTO.getIdOperazione().equals(GENERAZIONE_AVVISI_PAGAMENTO)){
-				it.govpay.core.business.Operazioni.setEseguiGenerazioneAvvisi();
-				esitoOperazione = "Generazione Avvisi Pagamento schedulata";
-			} else if(leggiOperazioneDTO.getIdOperazione().equals(ATTIVAZIONE_GENERAZIONE_AVVISI_PAGAMENTO)){
+			} else if(leggiOperazioneDTO.getIdOperazione().equals(GENERAZIONE_AVVISI_PAGAMENTO) ||
+					leggiOperazioneDTO.getIdOperazione().equals(ATTIVAZIONE_GENERAZIONE_AVVISI_PAGAMENTO)){
 				it.govpay.core.business.Operazioni.setEseguiGenerazioneAvvisi();
 				esitoOperazione = "Generazione Avvisi Pagamento schedulata";
 			} else if(leggiOperazioneDTO.getIdOperazione().equals(ELABORAZIONE_TRACCIATI_PENDENZE)){

--- a/jars/core/src/main/java/it/govpay/core/utils/client/BasicClientCORE.java
+++ b/jars/core/src/main/java/it/govpay/core/utils/client/BasicClientCORE.java
@@ -127,12 +127,17 @@ public abstract class BasicClientCORE {
 	private static Logger log = LoggerWrapperFactory.getLogger(BasicClientCORE.class);
 
 	protected boolean debug = true;
-	//	protected static Map<String, SSLContext> sslContexts = new HashMap<>();
 	protected URL url = null;
-	//	protected SSLContext sslContext;
-	protected boolean ishttpBasicEnabled=false, isSslEnabled=false, isSubscriptionKeyEnabled=false;
-	protected String httpBasicUser, httpBasicPassword;
-	protected String subscriptionKeyHeaderName, subscriptionKeyHeaderValue;
+	protected boolean ishttpBasicEnabled=false;
+	protected boolean isSslEnabled=false;
+	protected boolean isSubscriptionKeyEnabled=false;
+	protected boolean ishttpHeaderEnabled=false;
+	protected String httpBasicUser;
+	protected String httpBasicPassword;
+	protected String subscriptionKeyHeaderName;
+	protected String subscriptionKeyHeaderValue;
+	protected String httpHeaderName;
+	protected String httpHeaderValue;
 	protected String errMsg;
 	protected String destinatario;
 	protected String mittente;

--- a/jars/core/src/main/java/it/govpay/core/utils/client/BasicClientCORE.java
+++ b/jars/core/src/main/java/it/govpay/core/utils/client/BasicClientCORE.java
@@ -320,6 +320,14 @@ public abstract class BasicClientCORE {
 			this.getEventoCtx().setPrincipal(this.httpBasicUser);
 		}
 		
+		if(connettore.getTipoAutenticazione().equals(EnumAuthType.HTTP_HEADER)) {
+			this.ishttpHeaderEnabled = true;
+			this.httpHeaderName = connettore.getHttpHeaderName();
+			this.httpHeaderValue = connettore.getHttpHeaderValue();
+
+			this.getEventoCtx().setPrincipal(this.httpHeaderValue);
+		}
+		
 		if(connettore.getSubscriptionKeyValue() != null) {
 			// se non ho impostato nessuna autenticazione salvo SubscriptionKey come metodo di autenticazione per l'evento.
 			if(connettore.getTipoAutenticazione().equals(EnumAuthType.NONE)) {
@@ -622,6 +630,17 @@ public abstract class BasicClientCORE {
 				this.httpRequest.addHeader("Authorization", "Basic " + encoding);
 				if(this.debug)
 					log.debug("Impostato Header Authorization [Basic "+encoding+"]");
+			}
+			
+			// Authentication HTTP Header
+			if(this.ishttpHeaderEnabled) {
+				if(this.debug)
+					log.debug("Impostazione autenticazione...");
+				
+				this.dumpRequest.getHeaders().put(this.httpHeaderName, this.httpHeaderValue);
+				this.httpRequest.addHeader(this.httpHeaderName, this.httpHeaderValue);
+				if(this.debug)
+					log.debug("Impostato Autenticazione tramite Header HTTP [{}:{}]", this.httpHeaderName, this.httpHeaderValue);
 			}
 			
 			// Authentication Subscription Key

--- a/jars/orm-beans/src/main/java/it/govpay/model/Connettore.java
+++ b/jars/orm-beans/src/main/java/it/govpay/model/Connettore.java
@@ -39,9 +39,11 @@ public class Connettore extends Versionabile {
 	public static final String P_AZIONEINURL_NAME = "AZIONEINURL";
     public static final String P_VERSIONE = "VERSIONE";
     public static final String P_SUBSCRIPTION_KEY_VALUE = "SUBSCRIPTION_KEY_VALUE";
+	public static final String P_HTTP_HEADER_AUTH_HEADER_NAME_NAME = "HTTP_HEADER_AUTH_HEADER_NAME";
+	public static final String P_HTTP_HEADER_AUTH_HEADER_VALUE_NAME = "HTTP_HEADER_AUTH_HEADER_VALUE";
 	
 	public enum EnumAuthType {
-		SSL, HTTPBasic, NONE
+		SSL, HTTPBasic, HTTP_HEADER, NONE
 	}
 	
 	public enum EnumSslType {
@@ -69,6 +71,8 @@ public class Connettore extends Versionabile {
 	private String urlServiziAvvisatura;
 	private boolean azioneInUrl;
 	private String subscriptionKeyValue;
+	private String httpHeaderName;
+	private String httpHeaderValue;
 	
 	public Connettore() {
 	}
@@ -91,6 +95,8 @@ public class Connettore extends Versionabile {
 		this.tipoSsl = src.tipoSsl;
 		this.url = src.url;
 		this.urlServiziAvvisatura = src.urlServiziAvvisatura;
+		this.httpHeaderName = src.httpHeaderName;
+		this.httpHeaderValue = src.httpHeaderValue;
 	}
 		
 	public String getIdConnettore() {
@@ -197,5 +203,17 @@ public class Connettore extends Versionabile {
 	}
 	public void setSubscriptionKeyValue(String subscriptionKeyValue) {
 		this.subscriptionKeyValue = subscriptionKeyValue;
+	}
+	public String getHttpHeaderName() {
+		return httpHeaderName;
+	}
+	public void setHttpHeaderName(String httpHeaderName) {
+		this.httpHeaderName = httpHeaderName;
+	}
+	public String getHttpHeaderValue() {
+		return httpHeaderValue;
+	}
+	public void setHttpHeaderValue(String httpHeaderValue) {
+		this.httpHeaderValue = httpHeaderValue;
 	}
 }

--- a/jars/orm/src/main/java/it/govpay/bd/model/converter/ConnettoreConverter.java
+++ b/jars/orm/src/main/java/it/govpay/bd/model/converter/ConnettoreConverter.java
@@ -93,6 +93,14 @@ public class ConnettoreConverter {
 				if(Connettore.P_SUBSCRIPTION_KEY_VALUE.equals(connettore.getCodProprieta())) {
 					dto.setSubscriptionKeyValue(connettore.getValore());
 				}
+				
+				if(Connettore.P_HTTP_HEADER_AUTH_HEADER_NAME_NAME.equals(connettore.getCodProprieta())) {
+					dto.setHttpHeaderName(connettore.getValore());
+				}
+				
+				if(Connettore.P_HTTP_HEADER_AUTH_HEADER_VALUE_NAME.equals(connettore.getCodProprieta())) {
+					dto.setHttpHeaderValue(connettore.getValore());
+				}
 
 				if(Connettore.P_AZIONEINURL_NAME.equals(connettore.getCodProprieta())) {
 					dto.setAzioneInUrl(Boolean.parseBoolean(connettore.getValore()));
@@ -226,6 +234,22 @@ public class ConnettoreConverter {
 			vo.setCodConnettore(connettore.getIdConnettore());
 			vo.setCodProprieta(Connettore.P_SUBSCRIPTION_KEY_VALUE);
 			vo.setValore(connettore.getSubscriptionKeyValue());
+			voList.add(vo);
+		}
+		
+		if(connettore.getHttpHeaderName() != null && !connettore.getHttpHeaderName().trim().isEmpty()) {
+			it.govpay.orm.Connettore vo = new it.govpay.orm.Connettore();
+			vo.setCodConnettore(connettore.getIdConnettore());
+			vo.setCodProprieta(Connettore.P_HTTP_HEADER_AUTH_HEADER_NAME_NAME);
+			vo.setValore(connettore.getHttpHeaderName());
+			voList.add(vo);
+		}
+		
+		if(connettore.getHttpHeaderValue() != null && !connettore.getHttpHeaderValue().trim().isEmpty()) {
+			it.govpay.orm.Connettore vo = new it.govpay.orm.Connettore();
+			vo.setCodConnettore(connettore.getIdConnettore());
+			vo.setCodProprieta(Connettore.P_HTTP_HEADER_AUTH_HEADER_VALUE_NAME);
+			vo.setValore(connettore.getHttpHeaderValue());
 			voList.add(vo);
 		}
 		

--- a/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/TipoAutenticazione.java
+++ b/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/TipoAutenticazione.java
@@ -13,17 +13,19 @@ import it.govpay.core.exceptions.ValidationException;
 import it.govpay.core.utils.validator.IValidable;
 import it.govpay.core.utils.validator.ValidatorFactory;
 @com.fasterxml.jackson.annotation.JsonPropertyOrder({
-	"username",
-	"password",
-	"tipo",
-	"ksLocation",
-	"ksPassword",
-	"ksType",
-	"ksPKeyPasswd",
-	"tsLocation",
-	"tsPassword",
-	"tsType",
-	"sslType",
+"username",
+"password",
+"tipo",
+"ksLocation",
+"ksPassword",
+"ksType",
+"ksPKeyPasswd",
+"tsLocation",
+"tsPassword",
+"tsType",
+"sslType",
+"headerName",
+"headerValue",
 })
 public class TipoAutenticazione extends it.govpay.core.beans.JSONSerializable implements IValidable {
 
@@ -106,6 +108,12 @@ public class TipoAutenticazione extends it.govpay.core.beans.JSONSerializable im
 
 	@JsonProperty("sslType")
 	private String sslType = null;
+
+  @JsonProperty("headerName")
+  private String headerName = null;
+  
+  @JsonProperty("headerValue")
+  private String headerValue = null;
 
 	/**
 	 **/
@@ -322,6 +330,36 @@ public class TipoAutenticazione extends it.govpay.core.beans.JSONSerializable im
     this.sslType = sslType;
   }
 
+  /**
+   **/
+  public TipoAutenticazione headerName(String headerName) {
+    this.headerName = headerName;
+    return this;
+  }
+
+  @JsonProperty("headerName")
+  public String getHeaderName() {
+    return headerName;
+  }
+  public void setHeaderName(String headerName) {
+    this.headerName = headerName;
+  }
+
+  /**
+   **/
+  public TipoAutenticazione headerValue(String headerValue) {
+    this.headerValue = headerValue;
+    return this;
+  }
+
+  @JsonProperty("headerValue")
+  public String getHeaderValue() {
+    return headerValue;
+  }
+  public void setHeaderValue(String headerValue) {
+    this.headerValue = headerValue;
+  }
+
 	@Override
 	public boolean equals(java.lang.Object o) {
 		if (this == o) {
@@ -341,12 +379,14 @@ public class TipoAutenticazione extends it.govpay.core.beans.JSONSerializable im
 				Objects.equals(this.tsLocation, tipoAutenticazione.tsLocation) &&
 				Objects.equals(this.tsPassword, tipoAutenticazione.tsPassword)&&
 		        Objects.equals(tsType, tipoAutenticazione.tsType) &&
-		        Objects.equals(sslType, tipoAutenticazione.sslType);
+		        Objects.equals(sslType, tipoAutenticazione.sslType) &&
+        Objects.equals(headerName, tipoAutenticazione.headerName) &&
+        Objects.equals(headerValue, tipoAutenticazione.headerValue);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.username, this.password, this.tipo, this.ksLocation, this.ksPassword, ksType, ksPKeyPasswd, this.tsLocation, this.tsPassword, tsType, sslType);
+		return Objects.hash(this.username, this.password, this.tipo, this.ksLocation, this.ksPassword, ksType, ksPKeyPasswd, this.tsLocation, this.tsPassword, tsType, sslType, headerName, headerValue);
 	}
 
 	public static TipoAutenticazione parse(String json) throws IOException {
@@ -374,6 +414,8 @@ public class TipoAutenticazione extends it.govpay.core.beans.JSONSerializable im
 		sb.append("    tsPassword: ").append(this.toIndentedString(this.tsPassword)).append("\n");
 		sb.append("    tsType: ").append(toIndentedString(tsType)).append("\n");
 		sb.append("    sslType: ").append(toIndentedString(sslType)).append("\n");
+    sb.append("    headerName: ").append(toIndentedString(headerName)).append("\n");
+    sb.append("    headerValue: ").append(toIndentedString(headerValue)).append("\n");
 		sb.append("}");
 		return sb.toString();
 	}
@@ -394,33 +436,39 @@ public class TipoAutenticazione extends it.govpay.core.beans.JSONSerializable im
 
 		ValidatorFactory vf = ValidatorFactory.newInstance();
 		
-		// validazione credenziali httpbasic
-		if(this.username != null || this.password != null) {
-			vf.getValidator("username", this.username).notNull().minLength(1).maxLength(255);
-			vf.getValidator("password", this.password).notNull().minLength(1).maxLength(255);
+		// validazione credenziali http header
+		if(this.headerName != null || this.headerValue != null) {
+			vf.getValidator("headerName", this.headerName).notNull().minLength(1).maxLength(255);
+			vf.getValidator("headerValue", this.headerValue).notNull().minLength(1).maxLength(255);
 		} else {
-			vf.getValidator("tipo", this.tipo).notNull();
-			vf.getValidator("tsLocation", this.tsLocation).notNull().minLength(1).maxLength(255);
-			vf.getValidator("tsPassword", this.tsPassword).notNull().minLength(1).maxLength(255);
-		
-			vf.getValidator("tsType", this.tsType).notNull();
-			if(KeystoreType.fromValue(this.tsType) == null){
-				throw new ValidationException("Codifica inesistente per tsType. Valore fornito [" + this.tsType + "] valori possibili " + ArrayUtils.toString(KeystoreType.values()));
-			}
+			// validazione credenziali httpbasic
+			if(this.username != null || this.password != null) {
+				vf.getValidator("username", this.username).notNull().minLength(1).maxLength(255);
+				vf.getValidator("password", this.password).notNull().minLength(1).maxLength(255);
+			} else {
+				vf.getValidator("tipo", this.tipo).notNull();
+				vf.getValidator("tsLocation", this.tsLocation).notNull().minLength(1).maxLength(255);
+				vf.getValidator("tsPassword", this.tsPassword).notNull().minLength(1).maxLength(255);
 			
-			vf.getValidator("sslType", this.sslType).notNull();
-			if(SslConfigType.fromValue(this.sslType) == null)
-				throw new ValidationException("Codifica inesistente per sslType. Valore fornito [" + this.sslType + "] valori possibili " + ArrayUtils.toString(SslConfigType.values()));
-			
-			if(this.tipo.equals(TipoEnum.CLIENT)) {
-				vf.getValidator("ksLocation", this.ksLocation).notNull().minLength(1).maxLength(255);
-				vf.getValidator("ksPassword", this.ksPassword).notNull().minLength(1).maxLength(255);
-				vf.getValidator("ksType", this.ksType).notNull();
-				if(KeystoreType.fromValue(this.ksType) == null){
-					throw new ValidationException("Codifica inesistente per ksType. Valore fornito [" + this.ksType + "] valori possibili " + ArrayUtils.toString(KeystoreType.values()));
+				vf.getValidator("tsType", this.tsType).notNull();
+				if(KeystoreType.fromValue(this.tsType) == null){
+					throw new ValidationException("Codifica inesistente per tsType. Valore fornito [" + this.tsType + "] valori possibili " + ArrayUtils.toString(KeystoreType.values()));
 				}
 				
-				vf.getValidator("ksPKeyPasswd", this.ksPKeyPasswd).notNull().minLength(1).maxLength(255);
+				vf.getValidator("sslType", this.sslType).notNull();
+				if(SslConfigType.fromValue(this.sslType) == null)
+					throw new ValidationException("Codifica inesistente per sslType. Valore fornito [" + this.sslType + "] valori possibili " + ArrayUtils.toString(SslConfigType.values()));
+				
+				if(this.tipo.equals(TipoEnum.CLIENT)) {
+					vf.getValidator("ksLocation", this.ksLocation).notNull().minLength(1).maxLength(255);
+					vf.getValidator("ksPassword", this.ksPassword).notNull().minLength(1).maxLength(255);
+					vf.getValidator("ksType", this.ksType).notNull();
+					if(KeystoreType.fromValue(this.ksType) == null){
+						throw new ValidationException("Codifica inesistente per ksType. Valore fornito [" + this.ksType + "] valori possibili " + ArrayUtils.toString(KeystoreType.values()));
+					}
+					
+					vf.getValidator("ksPKeyPasswd", this.ksPKeyPasswd).notNull().minLength(1).maxLength(255);
+				}
 			}
 		}
 	}

--- a/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/TipoAutenticazioneHeader.java
+++ b/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/TipoAutenticazioneHeader.java
@@ -1,0 +1,103 @@
+package it.govpay.backoffice.v1.beans;
+
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import it.govpay.core.beans.JSONSerializable;
+import it.govpay.core.exceptions.IOException;
+@com.fasterxml.jackson.annotation.JsonPropertyOrder({
+"headerName",
+"headerValue",
+})
+public class TipoAutenticazioneHeader extends JSONSerializable {
+  
+  @JsonProperty("headerName")
+  private String headerName = null;
+  
+  @JsonProperty("headerValue")
+  private String headerValue = null;
+  
+  /**
+   **/
+  public TipoAutenticazioneHeader headerName(String headerName) {
+    this.headerName = headerName;
+    return this;
+  }
+
+  @JsonProperty("headerName")
+  public String getHeaderName() {
+    return headerName;
+  }
+  public void setHeaderName(String headerName) {
+    this.headerName = headerName;
+  }
+
+  /**
+   **/
+  public TipoAutenticazioneHeader headerValue(String headerValue) {
+    this.headerValue = headerValue;
+    return this;
+  }
+
+  @JsonProperty("headerValue")
+  public String getHeaderValue() {
+    return headerValue;
+  }
+  public void setHeaderValue(String headerValue) {
+    this.headerValue = headerValue;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TipoAutenticazioneHeader tipoAutenticazioneHeader = (TipoAutenticazioneHeader) o;
+    return Objects.equals(headerName, tipoAutenticazioneHeader.headerName) &&
+        Objects.equals(headerValue, tipoAutenticazioneHeader.headerValue);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(headerName, headerValue);
+  }
+
+  public static TipoAutenticazioneHeader parse(String json) throws IOException {
+    return (TipoAutenticazioneHeader) parse(json, TipoAutenticazioneHeader.class);
+  }
+
+  @Override
+  public String getJsonIdFilter() {
+    return "tipoAutenticazioneHeader";
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class TipoAutenticazioneHeader {\n");
+    
+    sb.append("    headerName: ").append(toIndentedString(headerName)).append("\n");
+    sb.append("    headerValue: ").append(toIndentedString(headerValue)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}
+
+
+

--- a/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/converter/ConnettoreNotificaPagamentiGovPayConverter.java
+++ b/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/converter/ConnettoreNotificaPagamentiGovPayConverter.java
@@ -138,22 +138,28 @@ public class ConnettoreNotificaPagamentiGovPayConverter {
 					connettore.setSslType(connector.getAuth().getSslType());
 					connettore.setSslKsType(connector.getAuth().getKsType());
 					connettore.setSslPKeyPasswd(connector.getAuth().getKsPKeyPasswd());
+					connettore.setHttpHeaderName(connector.getAuth().getHeaderName());
+					connettore.setHttpHeaderValue(connector.getAuth().getHeaderValue());
 
-					if(connector.getAuth().getTipo() != null) {
-						connettore.setTipoAutenticazione(EnumAuthType.SSL);
-						if(connector.getAuth().getTipo() != null) {
-							switch (connector.getAuth().getTipo()) {
-							case CLIENT:
-								connettore.setTipoSsl(EnumSslType.CLIENT);
-								break;
-							case SERVER:
-							default:
-								connettore.setTipoSsl(EnumSslType.SERVER);
-								break;
-							}
-						}
+					if(connector.getAuth().getHeaderName() != null) {
+						connettore.setTipoAutenticazione(EnumAuthType.HTTP_HEADER);
 					} else {
-						connettore.setTipoAutenticazione(EnumAuthType.HTTPBasic);
+						if(connector.getAuth().getTipo() != null) {
+							connettore.setTipoAutenticazione(EnumAuthType.SSL);
+							if(connector.getAuth().getTipo() != null) {
+								switch (connector.getAuth().getTipo()) {
+								case CLIENT:
+									connettore.setTipoSsl(EnumSslType.CLIENT);
+									break;
+								case SERVER:
+								default:
+									connettore.setTipoSsl(EnumSslType.SERVER);
+									break;
+								}
+							}
+						} else {
+							connettore.setTipoAutenticazione(EnumAuthType.HTTPBasic);
+						}
 					}
 				} else {
 					connettore.setTipoAutenticazione(EnumAuthType.NONE);

--- a/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/converter/ConnettorePagopaConverter.java
+++ b/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/converter/ConnettorePagopaConverter.java
@@ -22,22 +22,28 @@ public class ConnettorePagopaConverter {
 			connettore.setSslType(connector.getAuth().getSslType());
 			connettore.setSslKsType(connector.getAuth().getKsType());
 			connettore.setSslPKeyPasswd(connector.getAuth().getKsPKeyPasswd());
+			connettore.setHttpHeaderName(connector.getAuth().getHeaderName());
+			connettore.setHttpHeaderValue(connector.getAuth().getHeaderValue());
 			
-			if(connector.getAuth().getTipo() != null) {
-				connettore.setTipoAutenticazione(EnumAuthType.SSL);
-				if(connector.getAuth().getTipo() != null) {
-					switch (connector.getAuth().getTipo()) {
-					case CLIENT:
-						connettore.setTipoSsl(EnumSslType.CLIENT);
-						break;
-					case SERVER:
-					default:
-						connettore.setTipoSsl(EnumSslType.SERVER);
-						break;
-					}
-				}
+			if(connector.getAuth().getHeaderName() != null) {
+				connettore.setTipoAutenticazione(EnumAuthType.HTTP_HEADER);
 			} else {
-				connettore.setTipoAutenticazione(EnumAuthType.HTTPBasic);
+				if(connector.getAuth().getTipo() != null) {
+					connettore.setTipoAutenticazione(EnumAuthType.SSL);
+					if(connector.getAuth().getTipo() != null) {
+						switch (connector.getAuth().getTipo()) {
+						case CLIENT:
+							connettore.setTipoSsl(EnumSslType.CLIENT);
+							break;
+						case SERVER:
+						default:
+							connettore.setTipoSsl(EnumSslType.SERVER);
+							break;
+						}
+					}
+				} else {
+					connettore.setTipoAutenticazione(EnumAuthType.HTTPBasic);
+				}
 			}
 		} else {
 			connettore.setTipoAutenticazione(EnumAuthType.NONE);
@@ -52,7 +58,7 @@ public class ConnettorePagopaConverter {
 
 	public static ConnettorePagopa toRsModel(it.govpay.model.Connettore connettore) {
 		ConnettorePagopa rsModel = new ConnettorePagopa();
-		if(!connettore.getTipoAutenticazione().equals(EnumAuthType.NONE))
+		if(connettore.getTipoAutenticazione()!=null && !connettore.getTipoAutenticazione().equals(EnumAuthType.NONE))
 			rsModel.setAuth(toTipoAutenticazioneRsModel(connettore));
 		rsModel.setUrlRPT(connettore.getUrl());
 		rsModel.setUrlAvvisatura(connettore.getUrlServiziAvvisatura());
@@ -73,8 +79,10 @@ public class ConnettorePagopaConverter {
 		.tsType(connettore.getSslTsType())
 		.sslType(connettore.getSslType())
 		.ksType(connettore.getSslKsType())
-		.ksPKeyPasswd(connettore.getSslPKeyPasswd());
-		
+		.ksPKeyPasswd(connettore.getSslPKeyPasswd())
+		.headerName(connettore.getHttpHeaderName())
+		.headerValue(connettore.getHttpHeaderValue());
+
 		if(connettore.getTipoSsl() != null) {
 			switch (connettore.getTipoSsl() ) {
 			case CLIENT:

--- a/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/converter/ConnettoriConverter.java
+++ b/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/beans/converter/ConnettoriConverter.java
@@ -25,22 +25,28 @@ public class ConnettoriConverter {
 			connettore.setSslType(connector.getAuth().getSslType());
 			connettore.setSslKsType(connector.getAuth().getKsType());
 			connettore.setSslPKeyPasswd(connector.getAuth().getKsPKeyPasswd());
-
-			if(connector.getAuth().getTipo() != null) {
-				connettore.setTipoAutenticazione(EnumAuthType.SSL);
-				if(connector.getAuth().getTipo() != null) {
-					switch (connector.getAuth().getTipo()) {
-					case CLIENT:
-						connettore.setTipoSsl(EnumSslType.CLIENT);
-						break;
-					case SERVER:
-					default:
-						connettore.setTipoSsl(EnumSslType.SERVER);
-						break;
-					}
-				}
+			connettore.setHttpHeaderName(connector.getAuth().getHeaderName());
+			connettore.setHttpHeaderValue(connector.getAuth().getHeaderValue());
+			
+			if(connector.getAuth().getHeaderName() != null) {
+				connettore.setTipoAutenticazione(EnumAuthType.HTTP_HEADER);
 			} else {
-				connettore.setTipoAutenticazione(EnumAuthType.HTTPBasic);
+				if(connector.getAuth().getTipo() != null) {
+					connettore.setTipoAutenticazione(EnumAuthType.SSL);
+					if(connector.getAuth().getTipo() != null) {
+						switch (connector.getAuth().getTipo()) {
+						case CLIENT:
+							connettore.setTipoSsl(EnumSslType.CLIENT);
+							break;
+						case SERVER:
+						default:
+							connettore.setTipoSsl(EnumSslType.SERVER);
+							break;
+						}
+					}
+				} else {
+					connettore.setTipoAutenticazione(EnumAuthType.HTTPBasic);
+				}
 			}
 		} else {
 			connettore.setTipoAutenticazione(EnumAuthType.NONE);
@@ -76,7 +82,9 @@ public class ConnettoriConverter {
 		.tsType(connettore.getSslTsType())
 		.sslType(connettore.getSslType())
 		.ksType(connettore.getSslKsType())
-		.ksPKeyPasswd(connettore.getSslPKeyPasswd());
+		.ksPKeyPasswd(connettore.getSslPKeyPasswd())
+		.headerName(connettore.getHttpHeaderName())
+		.headerValue(connettore.getHttpHeaderValue());
 
 		if(connettore.getTipoSsl() != null) {
 			switch (connettore.getTipoSsl() ) {

--- a/wars/api-backoffice/src/main/webapp/v1/govpay-api-backoffice-v1.yaml
+++ b/wars/api-backoffice/src/main/webapp/v1/govpay-api-backoffice-v1.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "1.34.0"
+  version: "1.35.0"
   title: GovPay - API Backoffice
   contact:
     name: GitHub Project Page
@@ -7876,10 +7876,25 @@ components:
           $ref: '#/components/schemas/keystoreType'
         sslType:
           $ref: '#/components/schemas/sslConfigType'
+    tipoAutenticazioneHeader:
+      type: object
+      required:
+        - headerName
+        - headerValue
+      properties:
+        headerName:
+          type: string
+          example: X-GOVPAY-AUTH
+          maxLength: 255
+        headerValue:
+          type: string
+          example: ABCDE123456...
+          maxLength: 255
     tipoAutenticazione:
       oneOf:
         - $ref: '#/components/schemas/tipoAutenticazioneBasic'
         - $ref: '#/components/schemas/tipoAutenticazioneSSL'
+        - $ref: '#/components/schemas/tipoAutenticazioneHeader'
     connector:
       type: object
       required:
@@ -8902,8 +8917,6 @@ components:
         descrizione:
           type: string
           description: testo descrittivo
-          items:
-            $ref: '#/components/schemas/dominioIndex'
         stato:
           type: string
           description: stato dell'operazione (OK/KO/WARN)

--- a/wars/web-console/src/main/angular/console/src/app/elements/detail-view/views/applicazioni-view/applicazioni-view.component.ts
+++ b/wars/web-console/src/main/angular/console/src/app/elements/detail-view/views/applicazioni-view/applicazioni-view.component.ts
@@ -82,12 +82,18 @@ export class ApplicazioniViewComponent implements IModalDialog, OnInit, AfterVie
       _dettaglio.serviziApi.push(new Dato({ label: Voce.URL, value: this.json.servizioIntegrazione.url }));
       _dettaglio.serviziApi.push(new Dato({ label: Voce.VERSIONE_API, value: this.json.servizioIntegrazione.versioneApi }));
       if(this.json.servizioIntegrazione.auth) {
-        _dettaglio.serviziApi.push(new Dato({ label: Voce.TIPO_AUTH, value: this.json.servizioIntegrazione.auth.hasOwnProperty('username')?'HTTP Basic':'SSL' }));
+        if(this.json.servizioIntegrazione.auth.headerName) {
+		  _dettaglio.serviziApi.push(new Dato({ label: Voce.TIPO_AUTH, value: Voce.HTTP_HEADER }));
+          _dettaglio.serviziApi.push(new Dato({label: Voce.HEADER_NAME, value: this.json.servizioIntegrazione.auth.headerName }));
+          _dettaglio.serviziApi.push(new Dato({label: Voce.HEADER_VALUE, value: this.json.servizioIntegrazione.auth.headerValue }));
+        }
         if(this.json.servizioIntegrazione.auth.username) {
+		  _dettaglio.serviziApi.push(new Dato({ label: Voce.TIPO_AUTH, value: Voce.BASIC }));
           _dettaglio.serviziApi.push(new Dato({label: Voce.USERNAME, value: this.json.servizioIntegrazione.auth.username }));
           _dettaglio.serviziApi.push(new Dato({label: Voce.PASSWORD, value: this.json.servizioIntegrazione.auth.password }));
         }
         if(this.json.servizioIntegrazione.auth.tipo) {
+		  _dettaglio.serviziApi.push(new Dato({ label: Voce.TIPO_AUTH, value: Voce.SSL }));
           _dettaglio.serviziApi.push(new Dato({label: Voce.TIPO, value: this.json.servizioIntegrazione.auth.tipo }));
           if(this.json.servizioIntegrazione.auth.sslType) {
             _dettaglio.serviziApi.push(new Dato({label: Voce.SSL_CFG_TYPE, value: this.json.servizioIntegrazione.auth.sslType }));

--- a/wars/web-console/src/main/angular/console/src/app/elements/detail-view/views/registro-intermediari-view/registro-intermediari-view.component.ts
+++ b/wars/web-console/src/main/angular/console/src/app/elements/detail-view/views/registro-intermediari-view/registro-intermediari-view.component.ts
@@ -69,6 +69,11 @@ export class RegistroIntermediariViewComponent implements IModalDialog, OnInit, 
         _dettaglio.connettoriSoap.push(new Dato({ label: Voce.OCP_APIM_SUBSCRIPTION_KEY, value: this.json.servizioPagoPa.subscriptionKey }));
       }
       if(this.json.servizioPagoPa.auth) {
+		if(this.json.servizioPagoPa.auth.headerName) {
+		  _dettaglio.connettoriSoap.push(new Dato({ label: Voce.TIPO_AUTH, value: Voce.HTTP_HEADER }));
+          _dettaglio.connettoriSoap.push(new Dato({label: Voce.HEADER_NAME, value: this.json.servizioPagoPa.auth.headerName }));
+          _dettaglio.connettoriSoap.push(new Dato({label: Voce.HEADER_VALUE, value: this.json.servizioPagoPa.auth.headerValue }));
+        }
         if(this.json.servizioPagoPa.auth.username) {
           _dettaglio.connettoriSoap.push(new Dato({ label: Voce.TIPO_AUTH, value: Voce.BASIC }));
           _dettaglio.connettoriSoap.push(new Dato({label: Voce.USERNAME, value: this.json.servizioPagoPa.auth.username }));

--- a/wars/web-console/src/main/angular/console/src/app/elements/detail-view/views/ssl-config/ssl-config.component.html
+++ b/wars/web-console/src/main/angular/console/src/app/elements/detail-view/views/ssl-config/ssl-config.component.html
@@ -7,7 +7,7 @@
     <mat-option [value]="NESSUNA">{{NESSUNA}}</mat-option>
     <mat-option [value]="BASIC">HTTP Basic</mat-option>
     <mat-option [value]="SSL">SSL</mat-option>
-    <!-- <mat-option [value]="SUBSCRIPTIONKEY">Subscription Key</mat-option> -->
+    <mat-option [value]="HEADER">HTTP Header</mat-option>
   </mat-select>
 </mat-form-field>
 <div *ngIf="_isBasicAuth">
@@ -16,6 +16,14 @@
   </mat-form-field>
   <mat-form-field class="w-100" color="accent" [formGroup]="fGroup">
     <input matInput [placeholder]="voce.PASSWORD" formControlName="password_ctrl" autocomplete="off" [required]="_isRequired">
+  </mat-form-field>
+</div>
+<div *ngIf="_isHeaderAuth">
+  <mat-form-field class="w-100" color="accent" [formGroup]="fGroup">
+    <input matInput [placeholder]="voce.HEADER_NAME" formControlName="headerName_ctrl" autocomplete="off" [required]="_isRequired">
+  </mat-form-field>
+  <mat-form-field class="w-100" color="accent" [formGroup]="fGroup">
+    <input matInput [placeholder]="voce.HEADER_VALUE" formControlName="headerValue_ctrl" autocomplete="off" [required]="_isRequired">
   </mat-form-field>
 </div>
 <div *ngIf="_isSslAuth">

--- a/wars/web-console/src/main/angular/console/src/app/services/util.service.ts
+++ b/wars/web-console/src/main/angular/console/src/app/services/util.service.ts
@@ -335,6 +335,7 @@ export class UtilService {
 
   public static TIPI_AUTENTICAZIONE: any = {
     basic: 'HTTP Basic',
+    header: 'HTTP Header',
     ssl: 'SSL'
   };
 

--- a/wars/web-console/src/main/angular/console/src/app/services/voce.service.ts
+++ b/wars/web-console/src/main/angular/console/src/app/services/voce.service.ts
@@ -115,6 +115,10 @@ export class Voce {
   public static GLN: string = 'Global location number';
 
   public static HOSTNAME: string = 'Hostname';
+  public static HEADER: string = 'Header';
+  public static HEADER_NAME: string = 'Nome Header';
+  public static HEADER_VALUE: string = 'Valore';
+  public static HTTP_HEADER: string = 'HTTP Header';
 
   public static IBAN_ACCREDITO: string = 'Iban accredito';
   public static IBAN_POSTALE: string = 'Iban postale';


### PR DESCRIPTION
- Aggiunta possibilita' di configurare l'autenticazione HTTP Header per i connettori verso le API PagoPA e API Ente.
- Modificato componente client per utilizzare la nuova tipologia di autenticazione.
- Aggiunti test di configurazione e utilizzo della nuova tipologia.
- Allineato Cruscotto.
