### PR TITLE
643 keyword speciali da non stampare negli avvisi di pagamento

### DIFF
--- a/ear/src/main/application/properties/govpay.properties
+++ b/ear/src/main/application/properties/govpay.properties
@@ -272,6 +272,12 @@ it.govpay.checkout.enabled=${it.govpay.checkout.enabled}
 it.govpay.checkout.baseUrl=${it.govpay.checkout.baseUrl}
 
 
+# Govpay Stampe
+
+# Lista di keyword che se individuate all'interno dei campi CF e Anagrafica Debitore vengono sostituite con stringa vuota (separati da ',')
+it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword=${it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword}
+
+
 # Configurazione CORS
 
 # Indica se loggare gli errori CORS con severita' DEBUG al posto di ERROR.

--- a/ear/src/main/application_wildfly18/properties/govpay.properties
+++ b/ear/src/main/application_wildfly18/properties/govpay.properties
@@ -272,6 +272,12 @@ it.govpay.checkout.enabled=${it.govpay.checkout.enabled}
 it.govpay.checkout.baseUrl=${it.govpay.checkout.baseUrl}
 
 
+# Govpay Stampe
+
+# Lista di keyword che se individuate all'interno dei campi CF e Anagrafica Debitore vengono sostituite con stringa vuota (separati da ',')
+it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword=${it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword}
+
+
 # Configurazione CORS
 
 # Indica se loggare gli errori CORS con severita' DEBUG al posto di ERROR.

--- a/jars/core/src/main/java/it/govpay/core/utils/GovpayConfig.java
+++ b/jars/core/src/main/java/it/govpay/core/utils/GovpayConfig.java
@@ -194,6 +194,8 @@ public class GovpayConfig {
 	private boolean batchSpedizioneNotificheAppIO;
 	private boolean batchSpedizionePromemoria;
 	
+	private List<String> keywordsDaSostituireIdentificativiDebitoreAvviso;
+	
 	
 	public GovpayConfig(InputStream is) throws Exception {
 		// Default values:
@@ -286,6 +288,8 @@ public class GovpayConfig {
 		this.operazioneVerifica = null;
 		
 		this.numeroGiorniValiditaPendenza = null;
+		
+		this.keywordsDaSostituireIdentificativiDebitoreAvviso = new ArrayList<>();
 		
 		this.batchRecuperoRPTPendenti = false;
 		this.batchAcquisizioneRendicontazioni = false;
@@ -890,6 +894,14 @@ public class GovpayConfig {
 			if(batchSpedizionePromemoriaString != null && Boolean.valueOf(batchSpedizionePromemoriaString))
 				this.batchSpedizionePromemoria = true;
 			
+			String keywordsS = getProperty("it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword", props, false, log);
+			if(StringUtils.isNotEmpty(keywordsS)) {
+				String[] split = keywordsS.split(",");
+				if(split != null && split.length > 0) {
+					this.keywordsDaSostituireIdentificativiDebitoreAvviso = Arrays.asList(split);
+				}
+			}
+			
 		} catch (PropertyNotFoundException e) {
 			log.error(MessageFormat.format("Errore di inizializzazione: {0}", e.getMessage()));
 			throw new ConfigException(e);
@@ -1357,6 +1369,10 @@ public class GovpayConfig {
 
 	public boolean isBatchSpedizionePromemoria() {
 		return batchSpedizionePromemoria;
+	}
+
+	public List<String> getKeywordsDaSostituireIdentificativiDebitoreAvviso() {
+		return keywordsDaSostituireIdentificativiDebitoreAvviso;
 	}
 	
 }

--- a/jars/core/src/main/java/it/govpay/core/utils/stampe/AvvisoPagamentoUtils.java
+++ b/jars/core/src/main/java/it/govpay/core/utils/stampe/AvvisoPagamentoUtils.java
@@ -25,6 +25,7 @@ import it.govpay.core.beans.tracciati.ProprietaPendenza;
 import it.govpay.core.business.model.PrintAvvisoDocumentoDTO;
 import it.govpay.core.business.model.PrintAvvisoVersamentoDTO;
 import it.govpay.core.exceptions.UnprocessableEntityException;
+import it.govpay.core.utils.GovpayConfig;
 import it.govpay.core.utils.IuvUtils;
 import it.govpay.core.utils.LabelAvvisiProperties;
 import it.govpay.core.utils.VersamentoUtils;
@@ -593,11 +594,35 @@ public class AvvisoPagamentoUtils {
 			String capCittaDebitore = StringUtils.isNotEmpty(localitaDebitore) ? (capDebitore + " " + localitaDebitore + provinciaDebitore) : "";
 
 			input.setNomeCognomeDestinatario(anagraficaDebitore.getRagioneSociale());
-			input.setCfDestinatario(anagraficaDebitore.getCodUnivoco().toUpperCase());
+			if(anagraficaDebitore.getCodUnivoco() != null) {
+				input.setCfDestinatario(anagraficaDebitore.getCodUnivoco().toUpperCase());
+			}
 
 			input.setIndirizzoDestinatario1(indirizzoDestinatario);
-
 			input.setIndirizzoDestinatario2(capCittaDebitore);
+			
+			// Modifica per la sostituzione dei valori impostati negli identificativi del debitore con stringa vuota se 
+			// questi coincidono con una delle keyword indicate nelle proprieta' di sistema
+			List<String> keywordsDaSostituireIdentificativiDebitoreAvviso = GovpayConfig.getInstance().getKeywordsDaSostituireIdentificativiDebitoreAvviso();
+			if(keywordsDaSostituireIdentificativiDebitoreAvviso != null) {
+				if(input.getCfDestinatario() != null) {
+					for (String keyword : keywordsDaSostituireIdentificativiDebitoreAvviso) {
+						if(keyword.equalsIgnoreCase(input.getCfDestinatario())) {
+							input.setCfDestinatario("");
+							break;
+						}
+					}
+				}
+				
+				if(input.getNomeCognomeDestinatario() != null) {
+					for (String keyword : keywordsDaSostituireIdentificativiDebitoreAvviso) {
+						if(keyword.equalsIgnoreCase(input.getNomeCognomeDestinatario())) {
+							input.setNomeCognomeDestinatario("");
+							break;
+						}
+					}
+				}
+			}
 		}
 	}
 

--- a/jars/core/src/main/java/it/govpay/core/utils/stampe/AvvisoPagamentoV2Utils.java
+++ b/jars/core/src/main/java/it/govpay/core/utils/stampe/AvvisoPagamentoV2Utils.java
@@ -25,6 +25,7 @@ import it.govpay.core.business.model.PrintAvvisoDocumentoDTO;
 import it.govpay.core.business.model.PrintAvvisoVersamentoDTO;
 import it.govpay.core.exceptions.InvalidSwitchValueException;
 import it.govpay.core.exceptions.UnprocessableEntityException;
+import it.govpay.core.utils.GovpayConfig;
 import it.govpay.core.utils.IuvUtils;
 import it.govpay.core.utils.LabelAvvisiProperties;
 import it.govpay.core.utils.VersamentoUtils;
@@ -603,11 +604,35 @@ public class AvvisoPagamentoV2Utils {
 			String capCittaDebitore = StringUtils.isNotEmpty(localitaDebitore) ? (capDebitore + " " + localitaDebitore + provinciaDebitore) : "";
 
 			input.setNomeCognomeDestinatario(anagraficaDebitore.getRagioneSociale());
-			input.setCfDestinatario(anagraficaDebitore.getCodUnivoco().toUpperCase());
+			if(anagraficaDebitore.getCodUnivoco() != null) {
+				input.setCfDestinatario(anagraficaDebitore.getCodUnivoco().toUpperCase());
+			}
 
 			input.setIndirizzoDestinatario1(indirizzoDestinatario);
-
 			input.setIndirizzoDestinatario2(capCittaDebitore);
+			
+			// Modifica per la sostituzione dei valori impostati negli identificativi del debitore con stringa vuota se 
+			// questi coincidono con una delle keyword indicate nelle proprieta' di sistema
+			List<String> keywordsDaSostituireIdentificativiDebitoreAvviso = GovpayConfig.getInstance().getKeywordsDaSostituireIdentificativiDebitoreAvviso();
+			if(keywordsDaSostituireIdentificativiDebitoreAvviso != null) {
+				if(input.getCfDestinatario() != null) {
+					for (String keyword : keywordsDaSostituireIdentificativiDebitoreAvviso) {
+						if(keyword.equalsIgnoreCase(input.getCfDestinatario())) {
+							input.setCfDestinatario("");
+							break;
+						}
+					}
+				}
+				
+				if(input.getNomeCognomeDestinatario() != null) {
+					for (String keyword : keywordsDaSostituireIdentificativiDebitoreAvviso) {
+						if(keyword.equalsIgnoreCase(input.getNomeCognomeDestinatario())) {
+							input.setNomeCognomeDestinatario("");
+							break;
+						}
+					}
+				}
+			}
 		}
 	}
 	

--- a/src/main/resources/filters/installer_template.filter.properties
+++ b/src/main/resources/filters/installer_template.filter.properties
@@ -304,6 +304,13 @@ it.govpay.backoffice.gui.export.polling=15000
 # ambiente di deploy (lasciare vuoto in ambiente di produzione)
 it.govpay.backoffice.gui.ambienteDeploy=
 
+
+# Govpay Stampe
+
+# Lista di keyword che se individuate all'interno dei campi CF e Anagrafica Debitore vengono sostituite con stringa vuota (separati da ',')
+it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword=ANONIMO
+
+
 # Configurazione CORS
 
 # Indica se loggare gli errori CORS con severita' DEBUG al posto di ERROR.

--- a/src/main/resources/filters/installer_template.filter.properties
+++ b/src/main/resources/filters/installer_template.filter.properties
@@ -308,7 +308,7 @@ it.govpay.backoffice.gui.ambienteDeploy=
 # Govpay Stampe
 
 # Lista di keyword che se individuate all'interno dei campi CF e Anagrafica Debitore vengono sostituite con stringa vuota (separati da ',')
-it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword=ANONIMO
+it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword=
 
 
 # Configurazione CORS

--- a/src/main/resources/filters/template.filter.properties
+++ b/src/main/resources/filters/template.filter.properties
@@ -304,6 +304,13 @@ it.govpay.backoffice.gui.export.polling=15000
 # ambiente di deploy, viene mostrato come sfondo della console
 it.govpay.backoffice.gui.ambienteDeploy=
 
+
+# Govpay Stampe
+
+# Lista di keyword che se individuate all'interno dei campi CF e Anagrafica Debitore vengono sostituite con stringa vuota (separati da ',')
+it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword=ANONIMO
+
+
 # Configurazione CORS
 
 # Indica se loggare gli errori CORS con severita' DEBUG al posto di ERROR.

--- a/src/main/resources/filters/template.filter.properties
+++ b/src/main/resources/filters/template.filter.properties
@@ -308,7 +308,7 @@ it.govpay.backoffice.gui.ambienteDeploy=
 # Govpay Stampe
 
 # Lista di keyword che se individuate all'interno dei campi CF e Anagrafica Debitore vengono sostituite con stringa vuota (separati da ',')
-it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword=ANONIMO
+it.govpay.stampe.avvisoPagamento.identificativoDebitore.nascondiKeyword=
 
 
 # Configurazione CORS


### PR DESCRIPTION
Aggiunta gestione dell'identificativo debitore anonimo nel caso non si voglia stampare all'interno dell'avviso di pagamento.
E' stata aggiunta la possibilita' di definire un elenco di keyword che identificano il debitore anonimo che non si vogliono stampare.