### PR TITLE
Issue #625

### DIFF
--- a/jars/core/src/main/java/it/govpay/core/business/Promemoria.java
+++ b/jars/core/src/main/java/it/govpay/core/business/Promemoria.java
@@ -243,7 +243,9 @@ public class Promemoria {
 					versante = rptCtRichiestaPagamentoTelematico.getSoggettoVersante() != null ? rptCtRichiestaPagamentoTelematico.getSoggettoVersante().getEMailVersante() : null;
 					break;
 				case SANP_240:
+				case RPTV2_RTV1:
 				case SANP_321_V2:
+				case RPTV1_RTV2:
 					break;
 			}
 		}

--- a/jars/core/src/main/java/it/govpay/core/business/RicevutaTelematica.java
+++ b/jars/core/src/main/java/it/govpay/core/business/RicevutaTelematica.java
@@ -98,8 +98,10 @@ public class RicevutaTelematica {
 		case SANP_230:
 			return this._fromRpt(rpt);
 		case SANP_240:
+		case RPTV2_RTV1:
 			return this._fromRptVersione240(rpt);
 		case SANP_321_V2:
+		case RPTV1_RTV2:
 			return this._fromRptVersione321_V2(rpt);
 		}
 		

--- a/jars/core/src/main/java/it/govpay/core/business/TracciatiNotificaPagamenti.java
+++ b/jars/core/src/main/java/it/govpay/core/business/TracciatiNotificaPagamenti.java
@@ -1135,10 +1135,12 @@ public class TracciatiNotificaPagamenti {
 		
 		switch (versione) {
 		case SANP_240:
+		case RPTV2_RTV1:
 			return TracciatiNotificaPagamentiUtils.creaLineaCsvGovPayRpt_SANP24(rpt,configWrapper);
 		case SANP_230:
 			return TracciatiNotificaPagamentiUtils.creaLineaCsvGovPayRpt_SANP23(rpt,configWrapper);
 		case SANP_321_V2:
+		case RPTV1_RTV2:
 			return TracciatiNotificaPagamentiUtils.creaLineaCsvGovPayRpt_SANP321_V2(rpt,configWrapper);
 		}
 		
@@ -1168,10 +1170,12 @@ public class TracciatiNotificaPagamenti {
 		
 		switch (versione) {
 		case SANP_240:
+		case RPTV2_RTV1:
 			return TracciatiNotificaPagamentiUtils.creaLineaCsvMyPivotRpt_SANP24(rpt,configWrapper);
 		case SANP_230:
 			return TracciatiNotificaPagamentiUtils.creaLineaCsvMyPivotRpt_SANP23(rpt,configWrapper);
 		case SANP_321_V2:
+		case RPTV1_RTV2:
 			return TracciatiNotificaPagamentiUtils.creaLineaCsvMyPivotRpt_SANP321_V2(rpt,configWrapper);
 		}
 		
@@ -1184,12 +1188,14 @@ public class TracciatiNotificaPagamenti {
 		
 		switch (versione) {
 		case SANP_240:
+		case RPTV2_RTV1:
 			TracciatiNotificaPagamentiUtils.creaLineaCsvSecimRpt_SANP24(log, rpt, configWrapper, numeroLinea, connettore, secimOS, noSecimOS);
 			break;
 		case SANP_230:
 			TracciatiNotificaPagamentiUtils.creaLineaCsvSecimRpt_SANP23(log, rpt, configWrapper, numeroLinea, connettore, secimOS, noSecimOS);
 			break;
 		case SANP_321_V2:
+		case RPTV1_RTV2:
 			TracciatiNotificaPagamentiUtils.creaLineaCsvSecimRpt_SANP321_V2(log, rpt, configWrapper, numeroLinea, connettore, secimOS, noSecimOS);
 			break;
 		}

--- a/jars/core/src/main/java/it/govpay/core/dao/pagamenti/RptDAO.java
+++ b/jars/core/src/main/java/it/govpay/core/dao/pagamenti/RptDAO.java
@@ -138,9 +138,8 @@ public class RptDAO extends BaseDAO{
 				rpt.getPagamentoPortale().getApplicazione(configWrapper);
 			}
 			Versamento versamento = rpt.getVersamento();
-			response.setVersamento(versamento);
 			versamento.getTipoVersamentoDominio(configWrapper);
-			response.setTipoVersamento(versamento.getTipoVersamento(configWrapper));
+			
 			List<SingoloVersamento> singoliVersamenti = versamento.getSingoliVersamenti();
 			for (SingoloVersamento singoloVersamento : singoliVersamenti) {
 				singoloVersamento.getCodContabilita(configWrapper);
@@ -159,6 +158,8 @@ public class RptDAO extends BaseDAO{
 
 			response.setRpt(rpt);
 			response.setDominio(rpt.getDominio(configWrapper));
+			response.setVersamento(versamento);
+			response.setTipoVersamento(versamento.getTipoVersamento(configWrapper));
 		} catch (NotFoundException e) {
 			throw new RicevutaNonTrovataException(e.getMessage(), e);
 		} finally {

--- a/jars/core/src/main/java/it/govpay/core/ec/v2/converter/RicevuteConverter.java
+++ b/jars/core/src/main/java/it/govpay/core/ec/v2/converter/RicevuteConverter.java
@@ -87,6 +87,7 @@ public class RicevuteConverter {
 			ricevutaRpt.setXml(rpt.getXmlRpt());
 			switch (rpt.getVersione()) {
 			case SANP_240:
+			case RPTV1_RTV2:
 				PaGetPaymentRes paGetPaymentRes_RPT = JaxbUtils.toPaGetPaymentRes_RPT(rpt.getXmlRpt(), false);
 				ricevutaRpt.setTipo(it.govpay.ec.v2.beans.RicevutaRpt.TipoEnum.CTPAYMENTPA);
 				ricevutaRpt.setJson(new RawObject(ConverterUtils.getRptJson(rpt)));
@@ -103,6 +104,7 @@ public class RicevuteConverter {
 				rsModel.setImporto(ctRpt.getDatiVersamento().getImportoTotaleDaVersare());
 				break;
 			case SANP_321_V2:
+			case RPTV2_RTV1:
 				PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(rpt.getXmlRpt(), false);
 				ricevutaRpt.setTipo(it.govpay.ec.v2.beans.RicevutaRpt.TipoEnum.CTPAYMENTPA);
 				ricevutaRpt.setJson(new RawObject(ConverterUtils.getRptJson(rpt)));
@@ -123,6 +125,7 @@ public class RicevuteConverter {
 			try {
 				switch (rpt.getVersione()) {
 				case SANP_240:
+				case RPTV2_RTV1:
 					PaSendRTReq paSendRTReq_RT = JaxbUtils.toPaSendRTReq_RT(rpt.getXmlRt(), false);
 					ricevutaRt.setTipo(TipoEnum.CTRECEIPT);
 					ricevutaRt.setJson(new RawObject(ConverterUtils.getRtJson(rpt)));
@@ -137,6 +140,7 @@ public class RicevuteConverter {
 					rsModel.setVersante(PendenzeConverter.toSoggettoRsModel(ctRt.getSoggettoVersante()));
 					break;
 				case SANP_321_V2:
+				case RPTV1_RTV2:
 					PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(rpt.getXmlRt(), false);
 					ricevutaRt.setTipo(TipoEnum.CTRECEIPT);
 					ricevutaRt.setJson(new RawObject(ConverterUtils.getRtJson(rpt)));

--- a/jars/core/src/main/java/it/govpay/core/utils/MaggioliJPPAUtils.java
+++ b/jars/core/src/main/java/it/govpay/core/utils/MaggioliJPPAUtils.java
@@ -250,11 +250,13 @@ public class MaggioliJPPAUtils {
 		}
 		break;
 		case SANP_240:
+		case RPTV2_RTV1:
 		{
 			popolaRicevutaDaRPT24(ricevutaTelematica, rpt, versamento, singoliVersamenti, configWrapper);
 		}
 		break;
 		case SANP_321_V2:
+		case RPTV1_RTV2:
 		{
 			popolaRicevutaDaRPT32(ricevutaTelematica, rpt, versamento, singoliVersamenti, configWrapper);
 		}

--- a/jars/core/src/main/java/it/govpay/core/utils/rawutils/ConverterUtils.java
+++ b/jars/core/src/main/java/it/govpay/core/utils/rawutils/ConverterUtils.java
@@ -70,6 +70,7 @@ public class ConverterUtils {
 				CtRichiestaPagamentoTelematico ctRpt = JaxbUtils.toRPT(rpt.getXmlRpt(), false);
 				return toJSON(ctRpt);
 			case SANP_240:
+			case RPTV1_RTV2:
 				PaGetPaymentRes paGetPaymentRes_RPT = JaxbUtils.toPaGetPaymentRes_RPT(rpt.getXmlRpt(), false);
 				
 				if(convertiMessaggioPagoPAV2InPagoPAV1) {
@@ -78,6 +79,7 @@ public class ConverterUtils {
 				}
 				return toJSON(paGetPaymentRes_RPT.getData());
 			case SANP_321_V2:
+			case RPTV2_RTV1:
 				PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(rpt.getXmlRpt(), false);
 				
 				if(convertiMessaggioPagoPAV2InPagoPAV1) {
@@ -124,6 +126,7 @@ public class ConverterUtils {
 				CtRicevutaTelematica ctRt = JaxbUtils.toRT(rpt.getXmlRt(), false);
 				return toJSON(ctRt);
 			case SANP_240:
+			case RPTV2_RTV1:
 				PaSendRTReq paSendRTReq_RT = JaxbUtils.toPaSendRTReq_RT(rpt.getXmlRt(), false);
 				
 				if(convertiMessaggioPagoPAV2InPagoPAV1) {
@@ -133,6 +136,7 @@ public class ConverterUtils {
 				
 				return toJSON(paSendRTReq_RT.getReceipt());
 			case SANP_321_V2:
+			case RPTV1_RTV2:
 				PaSendRTV2Request paSendRTRtv2Request = JaxbUtils.toPaSendRTV2Request_RT(rpt.getXmlRt(), false);
 				
 				if(convertiMessaggioPagoPAV2InPagoPAV1) {

--- a/jars/orm-beans/src/main/java/it/govpay/model/Rpt.java
+++ b/jars/orm-beans/src/main/java/it/govpay/model/Rpt.java
@@ -176,7 +176,11 @@ public class Rpt extends BasicModel{
 		
 		SANP_321_V2,
 		SANP_240,
-		SANP_230;
+		SANP_230,
+		
+		RPTV2_RTV1,
+		RPTV1_RTV2
+		;
 		
 		public static VersioneRPT toEnum(String s) {
 			try {

--- a/jars/orm/src/main/java/it/govpay/bd/pagamento/RptBD.java
+++ b/jars/orm/src/main/java/it/govpay/bd/pagamento/RptBD.java
@@ -180,10 +180,14 @@ public class RptBD extends BasicBD {
 			exp.equals(RPT.model().COD_DOMINIO, codDominio);
 			exp.and();
 			exp.equals(RPT.model().IUV, iuv);
-			exp.and();
-			exp.equals(RPT.model().MODELLO_PAGAMENTO, modelloPagamento.getCodifica()+"");
-			exp.and();
-			exp.equals(RPT.model().VERSIONE, versione.toString());
+			if(modelloPagamento != null) {
+				exp.and();
+				exp.equals(RPT.model().MODELLO_PAGAMENTO, modelloPagamento.getCodifica()+"");
+			}
+			if(versione != null) {
+				exp.and();
+				exp.equals(RPT.model().VERSIONE, versione.toString());
+			}
 			
 			RPTFieldConverter converter = new RPTFieldConverter(this.getJdbcProperties().getDatabase());
 			CustomField cf = new CustomField("id", Long.class, "id", converter.toTable(RPT.model()));
@@ -199,8 +203,7 @@ public class RptBD extends BasicBD {
 				}
 			} 
 
-			throw new NotFoundException("Nessuna RPT Dominio: ["+codDominio+"], Iuv: ["+iuv+"], ModelloPagamento: ["+modelloPagamento.name()
-				+"], Versione: ["+versione.name()+"] corrisponde ai parametri indicati.");
+			throw new NotFoundException("Nessuna RPT Dominio: ["+codDominio+"], Iuv: ["+iuv+"], ModelloPagamento: ["+modelloPagamento+"], Versione: ["+versione+"] corrisponde ai parametri indicati.");
 		} catch (NotImplementedException e) {
 			throw new ServiceException(e);
 		} catch (ExpressionNotImplementedException e) {

--- a/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/controllers/RppController.java
+++ b/wars/api-backoffice/src/main/java/it/govpay/backoffice/v1/controllers/RppController.java
@@ -418,6 +418,7 @@ public class RppController extends BaseController {
 				this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName));
 				return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rpt),transactionId).build();
 			case SANP_240:
+			case RPTV1_RTV2:
 				PaGetPaymentRes paGetPaymentRes = JaxbUtils.toPaGetPaymentRes_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 				if(retrocompatibilitaMessaggiPagoPAV1) {
 					CtRichiestaPagamentoTelematico ctRpt2 = MessaggiPagoPAUtils.toCtRichiestaPagamentoTelematico(paGetPaymentRes, leggiRptDTOResponse.getRpt());
@@ -428,6 +429,7 @@ public class RppController extends BaseController {
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentRes.getData()),transactionId).build();
 				}
 			case SANP_321_V2:
+			case RPTV2_RTV1:
 				PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 				if(retrocompatibilitaMessaggiPagoPAV1) {
 					CtRichiestaPagamentoTelematico ctRpt2 = MessaggiPagoPAUtils.toCtRichiestaPagamentoTelematico(paGetPaymentV2Response, leggiRptDTOResponse.getRpt());
@@ -448,6 +450,7 @@ public class RppController extends BaseController {
 				this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName));
 				return this.handleResponseOk(Response.status(Status.OK).type(MediaType.TEXT_XML).entity(leggiRptDTOResponse.getRpt().getXmlRpt()),transactionId).build();
 			case SANP_240:
+			case RPTV1_RTV2:
 				if(retrocompatibilitaMessaggiPagoPAV1) {
 					PaGetPaymentRes paGetPaymentRes = JaxbUtils.toPaGetPaymentRes_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					CtRichiestaPagamentoTelematico ctRpt2 = MessaggiPagoPAUtils.toCtRichiestaPagamentoTelematico(paGetPaymentRes, leggiRptDTOResponse.getRpt());
@@ -458,6 +461,7 @@ public class RppController extends BaseController {
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.TEXT_XML).entity(leggiRptDTOResponse.getRpt().getXmlRpt()),transactionId).build();
 				}
 			case SANP_321_V2:
+			case RPTV2_RTV1:
 				if(retrocompatibilitaMessaggiPagoPAV1) {
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					CtRichiestaPagamentoTelematico ctRpt2 = MessaggiPagoPAUtils.toCtRichiestaPagamentoTelematico(paGetPaymentV2Response, leggiRptDTOResponse.getRpt());
@@ -560,6 +564,7 @@ public class RppController extends BaseController {
 						this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName));
 						return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rt),transactionId).build();
 					case SANP_240:
+					case RPTV2_RTV1:
 						PaSendRTReq paSendRTReq = JaxbUtils.toPaSendRTReq_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 						if(retrocompatibilitaMessaggiPagoPAV1) {
 							CtRicevutaTelematica ctRt2 = MessaggiPagoPAUtils.toCtRicevutaTelematica(paSendRTReq, ricevutaDTOResponse.getRpt());
@@ -570,6 +575,7 @@ public class RppController extends BaseController {
 							return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTReq.getReceipt()),transactionId).build();
 						}
 					case SANP_321_V2:
+					case RPTV1_RTV2:
 						PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 						if(retrocompatibilitaMessaggiPagoPAV1) {
 							CtRicevutaTelematica ctRt2 = MessaggiPagoPAUtils.toCtRicevutaTelematica(paSendRTV2Request, ricevutaDTOResponse.getRpt());
@@ -603,6 +609,7 @@ public class RppController extends BaseController {
 						this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName));
 						return this.handleResponseOk(Response.status(Status.OK).type(MediaType.TEXT_XML).entity(ricevutaDTOResponse.getRpt().getXmlRt()),transactionId).build();
 					case SANP_240:
+					case RPTV2_RTV1:
 						if(retrocompatibilitaMessaggiPagoPAV1) {
 							PaSendRTReq paSendRTReq = JaxbUtils.toPaSendRTReq_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 							CtRicevutaTelematica ctRt2 = MessaggiPagoPAUtils.toCtRicevutaTelematica(paSendRTReq, ricevutaDTOResponse.getRpt());
@@ -613,6 +620,7 @@ public class RppController extends BaseController {
 							return this.handleResponseOk(Response.status(Status.OK).type(MediaType.TEXT_XML).entity(ricevutaDTOResponse.getRpt().getXmlRt()),transactionId).build();
 						}
 					case SANP_321_V2:
+					case RPTV1_RTV2:
 						if(retrocompatibilitaMessaggiPagoPAV1) {
 							PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 							CtRicevutaTelematica ctRt2 = MessaggiPagoPAUtils.toCtRicevutaTelematica(paSendRTV2Request, ricevutaDTOResponse.getRpt());

--- a/wars/api-pagamento/src/main/java/it/govpay/pagamento/v1/beans/converter/RptConverter.java
+++ b/wars/api-pagamento/src/main/java/it/govpay/pagamento/v1/beans/converter/RptConverter.java
@@ -120,6 +120,7 @@ public class RptConverter {
 					rsModel.setRpt(ConverterUtils.getRptJson(ctRpt));
 					break;
 				case SANP_240:
+				case RPTV1_RTV2:
 					PaGetPaymentRes paGetPaymentRes_RPT = JaxbUtils.toPaGetPaymentRes_RPT(rpt.getXmlRpt(), false);
 					
 					CtPaymentPA data = paGetPaymentRes_RPT.getData();
@@ -143,6 +144,7 @@ public class RptConverter {
 					}
 					break;
 				case SANP_321_V2:
+				case RPTV2_RTV1:
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(rpt.getXmlRpt(), false);
 					
 					CtPaymentPAV2 dataV2 = paGetPaymentV2Response.getData();
@@ -230,6 +232,7 @@ public class RptConverter {
 					rsModel.setRt(ConverterUtils.getRtJson(ctRt));
 					break;
 				case SANP_240:
+				case RPTV2_RTV1:
 					PaSendRTReq paSendRTReq_RT = JaxbUtils.toPaSendRTReq_RT(rpt.getXmlRt(), false);
 					
 					CtReceipt data = paSendRTReq_RT.getReceipt();
@@ -253,6 +256,7 @@ public class RptConverter {
 					}
 					break;
 				case SANP_321_V2:
+				case RPTV1_RTV2:
 					PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(rpt.getXmlRt(), false);
 					
 					CtReceiptV2 dataV2 = paSendRTV2Request.getReceipt();
@@ -353,6 +357,7 @@ public class RptConverter {
 					rsModel.setRpt(ConverterUtils.getRptJson(ctRpt));
 					break;
 				case SANP_240:
+				case RPTV1_RTV2:
 					PaGetPaymentRes paGetPaymentRes_RPT = JaxbUtils.toPaGetPaymentRes_RPT(rpt.getXmlRpt(), false);
 					
 					CtPaymentPA data = paGetPaymentRes_RPT.getData();
@@ -376,6 +381,7 @@ public class RptConverter {
 					}
 					break;
 				case SANP_321_V2:
+				case RPTV2_RTV1:
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(rpt.getXmlRpt(), false);
 					
 					CtPaymentPAV2 dataV2 = paGetPaymentV2Response.getData();
@@ -464,6 +470,7 @@ public class RptConverter {
 					rsModel.setRt(ConverterUtils.getRtJson(ctRt));
 					break;
 				case SANP_240:
+				case RPTV2_RTV1:
 					PaSendRTReq paSendRTReq_RT = JaxbUtils.toPaSendRTReq_RT(rpt.getXmlRt(), false);
 					
 					CtReceipt data = paSendRTReq_RT.getReceipt();
@@ -487,6 +494,7 @@ public class RptConverter {
 					}
 					break;
 				case SANP_321_V2:
+				case RPTV1_RTV2:
 					PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(rpt.getXmlRt(), false);
 					
 					CtReceiptV2 dataV2 = paSendRTV2Request.getReceipt();

--- a/wars/api-pagamento/src/main/java/it/govpay/pagamento/v1/controller/RppController.java
+++ b/wars/api-pagamento/src/main/java/it/govpay/pagamento/v1/controller/RppController.java
@@ -272,10 +272,12 @@ public class RppController extends BaseController {
 						this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 						return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rt),transactionId).build();
 					case SANP_240:
+					case RPTV2_RTV1:
 						PaSendRTReq paSendRTReq = JaxbUtils.toPaSendRTReq_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 						this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 						return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTReq.getReceipt()),transactionId).build();
 					case SANP_321_V2:
+					case RPTV1_RTV2:
 						PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 						this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 						return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTV2Request.getReceipt()),transactionId).build();
@@ -337,9 +339,11 @@ public class RppController extends BaseController {
 					CtRichiestaPagamentoTelematico rpt = JaxbUtils.toRPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rpt),transactionId).build();
 				case SANP_240:
+				case RPTV1_RTV2:
 					PaGetPaymentRes paGetPaymentRes = JaxbUtils.toPaGetPaymentRes_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentRes.getData()),transactionId).build();
 				case SANP_321_V2:
+				case RPTV2_RTV1:
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentV2Response.getData()),transactionId).build();
 				}

--- a/wars/api-pagamento/src/main/java/it/govpay/pagamento/v2/beans/converter/RptConverter.java
+++ b/wars/api-pagamento/src/main/java/it/govpay/pagamento/v2/beans/converter/RptConverter.java
@@ -122,6 +122,7 @@ public class RptConverter {
 					rsModel.setRpt(new RawObject(ConverterUtils.getRptJson(ctRpt)));
 					break;
 				case SANP_240:
+				case RPTV1_RTV2:
 					PaGetPaymentRes paGetPaymentRes_RPT = JaxbUtils.toPaGetPaymentRes_RPT(rpt.getXmlRpt(), false);
 					
 					CtPaymentPA data = paGetPaymentRes_RPT.getData();
@@ -145,6 +146,7 @@ public class RptConverter {
 					}
 					break;
 				case SANP_321_V2:
+				case RPTV2_RTV1:
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(rpt.getXmlRpt(), false);
 					
 					CtPaymentPAV2 dataV2 = paGetPaymentV2Response.getData();
@@ -233,6 +235,7 @@ public class RptConverter {
 					rsModel.setRt(new RawObject(ConverterUtils.getRtJson(ctRt)));
 					break;
 				case SANP_240:
+				case RPTV2_RTV1:
 					PaSendRTReq paSendRTReq_RT = JaxbUtils.toPaSendRTReq_RT(rpt.getXmlRt(), false);
 					
 					CtReceipt data = paSendRTReq_RT.getReceipt();
@@ -256,6 +259,7 @@ public class RptConverter {
 					}
 					break;
 				case SANP_321_V2:
+				case RPTV1_RTV2:
 					PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(rpt.getXmlRt(), false);
 					
 					CtReceiptV2 dataV2 = paSendRTV2Request.getReceipt();
@@ -356,6 +360,7 @@ public class RptConverter {
 					rsModel.setRpt(new RawObject(ConverterUtils.getRptJson(ctRpt)));
 					break;
 				case SANP_240:
+				case RPTV1_RTV2:
 					PaGetPaymentRes paGetPaymentRes_RPT = JaxbUtils.toPaGetPaymentRes_RPT(rpt.getXmlRpt(), false);
 					
 					CtPaymentPA data = paGetPaymentRes_RPT.getData();
@@ -379,6 +384,7 @@ public class RptConverter {
 					}
 					break;
 				case SANP_321_V2:
+				case RPTV2_RTV1:
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(rpt.getXmlRpt(), false);
 					
 					CtPaymentPAV2 dataV2 = paGetPaymentV2Response.getData();
@@ -467,6 +473,7 @@ public class RptConverter {
 					rsModel.setRt(new RawObject(ConverterUtils.getRtJson(ctRt)));
 					break;
 				case SANP_240:
+				case RPTV2_RTV1:
 					PaSendRTReq paSendRTReq_RT = JaxbUtils.toPaSendRTReq_RT(rpt.getXmlRt(), false);
 					
 					CtReceipt data = paSendRTReq_RT.getReceipt();
@@ -490,6 +497,7 @@ public class RptConverter {
 					}
 					break;
 				case SANP_321_V2:
+				case RPTV1_RTV2:
 					PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(rpt.getXmlRt(), false);
 					
 					CtReceiptV2 dataV2 = paSendRTV2Request.getReceipt();

--- a/wars/api-pagamento/src/main/java/it/govpay/pagamento/v2/controller/RppController.java
+++ b/wars/api-pagamento/src/main/java/it/govpay/pagamento/v2/controller/RppController.java
@@ -286,10 +286,12 @@ public class RppController extends BaseController {
 						this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 						return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rt),transactionId).build();
 					case SANP_240:
+					case RPTV2_RTV1:
 						PaSendRTReq paSendRTReq = JaxbUtils.toPaSendRTReq_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 						this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 						return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTReq.getReceipt()),transactionId).build();
 					case SANP_321_V2:
+					case RPTV1_RTV2:
 						PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 						this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 						return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTV2Request.getReceipt()),transactionId).build();
@@ -351,9 +353,11 @@ public class RppController extends BaseController {
 					CtRichiestaPagamentoTelematico rpt = JaxbUtils.toRPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rpt),transactionId).build();
 				case SANP_240:
+				case RPTV1_RTV2:
 					PaGetPaymentRes paGetPaymentRes = JaxbUtils.toPaGetPaymentRes_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentRes.getData()),transactionId).build();
 				case SANP_321_V2:
+				case RPTV2_RTV1:
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentV2Response.getData()),transactionId).build();
 				}

--- a/wars/api-pagamento/src/main/java/it/govpay/pagamento/v3/beans/converter/RicevuteConverter.java
+++ b/wars/api-pagamento/src/main/java/it/govpay/pagamento/v3/beans/converter/RicevuteConverter.java
@@ -117,6 +117,7 @@ public class RicevuteConverter {
 			ricevutaRpt.setXml(rpt.getXmlRpt());
 			switch (rpt.getVersione()) {
 			case SANP_240:
+			case RPTV1_RTV2:
 				PaGetPaymentRes paGetPaymentRes_RPT = JaxbUtils.toPaGetPaymentRes_RPT(rpt.getXmlRpt(), false);
 				
 				CtPaymentPA data = paGetPaymentRes_RPT.getData();
@@ -198,6 +199,7 @@ public class RicevuteConverter {
 				rsModel.setImporto(ctRpt.getDatiVersamento().getImportoTotaleDaVersare());
 				break;
 			case SANP_321_V2:
+			case RPTV2_RTV1:
 				PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(rpt.getXmlRpt(), false);
 				
 				CtPaymentPAV2 dataV2 = paGetPaymentV2Response.getData();
@@ -232,6 +234,7 @@ public class RicevuteConverter {
 			try {
 				switch (rpt.getVersione()) {
 				case SANP_240:
+				case RPTV2_RTV1:
 					PaSendRTReq paSendRTReq_RT = JaxbUtils.toPaSendRTReq_RT(rpt.getXmlRt(), false);
 					
 					CtReceipt data = paSendRTReq_RT.getReceipt();
@@ -309,6 +312,7 @@ public class RicevuteConverter {
 					rsModel.setImporto(ctRt.getDatiPagamento().getImportoTotalePagato());
 					break;
 				case SANP_321_V2:
+				case RPTV1_RTV2:
 					PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(rpt.getXmlRt(), false);
 					
 					CtReceiptV2 dataV2 = paSendRTV2Request.getReceipt();

--- a/wars/api-pagopa/src/main/java/it/govpay/web/ws/PagamentiTelematiciCCPImpl.java
+++ b/wars/api-pagopa/src/main/java/it/govpay/web/ws/PagamentiTelematiciCCPImpl.java
@@ -110,6 +110,7 @@ import it.govpay.core.exceptions.VersamentoScadutoException;
 import it.govpay.core.exceptions.VersamentoSconosciutoException;
 import it.govpay.core.utils.CtPaymentPABuilder;
 import it.govpay.core.utils.CtReceiptUtils;
+import it.govpay.core.utils.CtReceiptV2Utils;
 import it.govpay.core.utils.GovpayConfig;
 import it.govpay.core.utils.GpContext;
 import it.govpay.core.utils.IuvUtils;
@@ -2057,7 +2058,7 @@ public class PagamentiTelematiciCCPImpl implements PagamentiTelematiciCCP {
 				throw new NdpException(FaultPa.PAA_STAZIONE_INT_ERRATA, codDominio);
 			}
 
-			Rpt rpt = CtReceiptUtils.acquisisciRT(codDominio, iuv, requestBody, false);
+			Rpt rpt = CtReceiptV2Utils.acquisisciRT(codDominio, iuv, requestBody, false);
 
 			appContext.getEventoCtx().setIdA2A(rpt.getVersamento(configWrapper).getApplicazione(configWrapper).getCodApplicazione());
 			appContext.getEventoCtx().setIdPendenza(rpt.getVersamento(configWrapper).getCodVersamentoEnte());

--- a/wars/api-pendenze/src/main/java/it/govpay/pendenze/v1/controller/RppController.java
+++ b/wars/api-pendenze/src/main/java/it/govpay/pendenze/v1/controller/RppController.java
@@ -287,10 +287,12 @@ public class RppController extends BaseController {
 							this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 							return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rt),transactionId).build();
 						case SANP_240:
+						case RPTV2_RTV1:
 							PaSendRTReq paSendRTReq = JaxbUtils.toPaSendRTReq_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 							this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 							return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTReq.getReceipt()),transactionId).build();
 						case SANP_321_V2:
+						case RPTV1_RTV2:
 							PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 							this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 							return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTV2Request.getReceipt()),transactionId).build();
@@ -365,9 +367,11 @@ public class RppController extends BaseController {
 					CtRichiestaPagamentoTelematico rpt = JaxbUtils.toRPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rpt),transactionId).build();
 				case SANP_240:
+				case RPTV1_RTV2:
 					PaGetPaymentRes paGetPaymentRes = JaxbUtils.toPaGetPaymentRes_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentRes.getData()),transactionId).build();
 				case SANP_321_V2:
+				case RPTV2_RTV1:
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentV2Response.getData()),transactionId).build();
 				}

--- a/wars/api-pendenze/src/main/java/it/govpay/pendenze/v2/controller/RppController.java
+++ b/wars/api-pendenze/src/main/java/it/govpay/pendenze/v2/controller/RppController.java
@@ -301,10 +301,12 @@ public class RppController extends BaseController {
 							this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 							return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rt),transactionId).build();
 						case SANP_240:
+						case RPTV2_RTV1:
 							PaSendRTReq paSendRTReq = JaxbUtils.toPaSendRTReq_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 							this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 							return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTReq.getReceipt()),transactionId).build();
 						case SANP_321_V2:
+						case RPTV1_RTV2:
 							PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(ricevutaDTOResponse.getRpt().getXmlRt(), false);
 							this.log.debug(MessageFormat.format(BaseController.LOG_MSG_ESECUZIONE_METODO_COMPLETATA, methodName)); 
 							return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paSendRTV2Request.getReceipt()),transactionId).build();
@@ -379,9 +381,11 @@ public class RppController extends BaseController {
 					CtRichiestaPagamentoTelematico rpt = JaxbUtils.toRPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(rpt),transactionId).build();
 				case SANP_240:
+				case RPTV1_RTV2:
 					PaGetPaymentRes paGetPaymentRes = JaxbUtils.toPaGetPaymentRes_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentRes.getData()),transactionId).build();
 				case SANP_321_V2:
+				case RPTV2_RTV1:
 					PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(leggiRptDTOResponse.getRpt().getXmlRpt(), false);
 					return this.handleResponseOk(Response.status(Status.OK).type(MediaType.APPLICATION_JSON).entity(paGetPaymentV2Response.getData()),transactionId).build();
 				}

--- a/wars/api-ragioneria/src/main/java/it/govpay/ragioneria/v3/beans/converter/RicevuteConverter.java
+++ b/wars/api-ragioneria/src/main/java/it/govpay/ragioneria/v3/beans/converter/RicevuteConverter.java
@@ -103,6 +103,7 @@ public class RicevuteConverter {
 			ricevutaRpt.setXml(rpt.getXmlRpt());
 			switch (rpt.getVersione()) {
 			case SANP_240:
+			case RPTV1_RTV2:
 				PaGetPaymentRes paGetPaymentRes_RPT = JaxbUtils.toPaGetPaymentRes_RPT(rpt.getXmlRpt(), false);
 				ricevutaRpt.setTipo(it.govpay.ragioneria.v3.beans.RicevutaRpt.TipoEnum.CTPAYMENTPA);
 				ricevutaRpt.setJson(new RawObject(ConverterUtils.getRptJson(rpt)));
@@ -119,6 +120,7 @@ public class RicevuteConverter {
 				rsModel.setImporto(ctRpt.getDatiVersamento().getImportoTotaleDaVersare());
 				break;
 			case SANP_321_V2:
+			case RPTV2_RTV1:
 				PaGetPaymentV2Response paGetPaymentV2Response = JaxbUtils.toPaGetPaymentV2Response_RPT(rpt.getXmlRpt(), false);
 				ricevutaRpt.setTipo(it.govpay.ragioneria.v3.beans.RicevutaRpt.TipoEnum.CTPAYMENTPA);
 				ricevutaRpt.setJson(new RawObject(ConverterUtils.getRptJson(rpt)));
@@ -139,6 +141,7 @@ public class RicevuteConverter {
 			try {
 				switch (rpt.getVersione()) {
 				case SANP_240:
+				case RPTV2_RTV1:
 					PaSendRTReq paSendRTReq_RT = JaxbUtils.toPaSendRTReq_RT(rpt.getXmlRt(), false);
 					ricevutaRt.setTipo(TipoEnum.CTRECEIPT);
 					ricevutaRt.setJson(new RawObject(ConverterUtils.getRtJson(rpt)));
@@ -151,6 +154,7 @@ public class RicevuteConverter {
 					rsModel.setImporto(ctRt.getDatiPagamento().getImportoTotalePagato());
 					break;
 				case SANP_321_V2:
+				case RPTV1_RTV2:
 					PaSendRTV2Request paSendRTV2Request = JaxbUtils.toPaSendRTV2Request_RT(rpt.getXmlRt(), false);
 					ricevutaRt.setTipo(TipoEnum.CTRECEIPT);
 					ricevutaRt.setJson(new RawObject(ConverterUtils.getRtJson(rpt)));


### PR DESCRIPTION
L'acquisizione della RT tramite le primitive paSendRT/paSendRTV2 avviene con successo a prescindere dalla primitiva utilizzata per l'attivazione della RPT. Questo consente di avere nel sistema delle transazioni ibride gestite tramite primitive differenti.