### PR TITLE
Upload SBOM su Dependency-Track nella pipeline

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -207,7 +207,8 @@ jobs:
             -DoutputFormat=all \
             -DschemaVersion=${SBOM_CYCLONEDX_SCHEMA_VERSION} \
             -DskipNotDeployed=false \
-            -DincludeTestScope=false
+            -DincludeTestScope=false \
+            -DprojectType=application
           ls -la sbom/cyclonedx/
 
       - name: Upload SBOM artifact

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -218,6 +218,96 @@ jobs:
           path: sbom/
           retention-days: 30
 
+  # ── Upload SBOM su Dependency-Track ──────────────────────────────────
+  # Traduzione del job GitLab dependency-track-upload.
+  # Esecuzione: sui tag, su master e sulle linee di manutenzione x.y.x
+  # (quindi anche 3.10.x), con la stessa condizione usata da docker_dev.
+  # Forzabile con FORCE_DTRACK_UPLOAD_JOB, disattivabile del tutto con
+  # DISABLE_DTRACK_UPLOAD_JOB, che ha la precedenza su tutto il resto.
+  dependency-track-upload:
+    needs: [ sbom ]
+    if: >-
+      vars.DISABLE_DTRACK_UPLOAD_JOB != 'true' &&
+      (github.ref_type == 'tag' ||
+       github.ref == 'refs/heads/master' || endsWith(github.ref, '.x') ||
+       vars.FORCE_DTRACK_UPLOAD_JOB == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # Come su GitLab, il fallimento blocca solo tag, master e linee x.y.x;
+    # le esecuzioni forzate su altri branch sono tolleranti.
+    continue-on-error: ${{ github.ref_type != 'tag' && github.ref != 'refs/heads/master' && !endsWith(github.ref, '.x') }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download SBOM
+        uses: actions/download-artifact@v7
+        with:
+          name: sbom-report
+          path: sbom/
+
+      - name: Verifica prerequisiti
+        env:
+          DTRACK_API_KEY: ${{ secrets.GOVPAY_DTRACK_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DTRACK_API_KEY}" ]; then
+            echo "ERRORE: secret GOVPAY_DTRACK_API_KEY non configurato."
+            exit 1
+          fi
+          if [ ! -f script/sbom/upload-sbom-parent-required.sh ]; then
+            echo "ERRORE: script script/sbom/upload-sbom-parent-required.sh non presente nel repository."
+            exit 1
+          fi
+          if [ ! -f "sbom/cyclonedx/bom.cdx.json" ]; then
+            echo "ERRORE: SBOM non trovato in sbom/cyclonedx/bom.cdx.json"
+            ls -R sbom/ || true
+            exit 1
+          fi
+          echo "SBOM: $(wc -c < sbom/cyclonedx/bom.cdx.json) byte"
+
+      # Su tag la versione e' il tag ed e' marcata latest; su master e sulle
+      # linee x.y.x la versione e' il nome del branch, cosi' master e 3.10.x
+      # convivono come versioni distinte dello stesso progetto.
+      - name: Determina versione Dependency-Track
+        id: dtrack
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          set -euo pipefail
+          if [ "$REF_TYPE" = "tag" ]; then
+            VERSION="$REF_NAME"; LATEST="true"
+          else
+            case "$REF_NAME" in
+              master|*.x) VERSION="$REF_NAME"; LATEST="false" ;;
+              *)          VERSION="dev";       LATEST="false" ;;
+            esac
+          fi
+          echo "Versione Dependency-Track: $VERSION (latest=$LATEST)"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+
+      # L'artifactId dell'aggregatore e' "bom": senza override il progetto
+      # comparirebbe su Dependency-Track con quel nome. DTRACK_PROJECT_NAME
+      # lo forza a "govpay".
+      - name: Upload SBOM su Dependency-Track
+        env:
+          DTRACK_API_KEY: ${{ secrets.GOVPAY_DTRACK_API_KEY }}
+          WORKSPACE: ${{ github.workspace }}
+          DTRACK_PROJECT_NAME: govpay
+          DTRACK_VERSION: ${{ steps.dtrack.outputs.version }}
+          DTRACK_LATEST: ${{ steps.dtrack.outputs.latest }}
+        run: |
+          set -euo pipefail
+          chmod +x script/sbom/upload-sbom-parent-required.sh
+          ./script/sbom/upload-sbom-parent-required.sh \
+            "${DTRACK_API_KEY}" \
+            "${WORKSPACE}/sbom/cyclonedx/bom.cdx.json" \
+            "GovPay-Legacy"
+
   # ── GitHub Release (solo tag) ────────────────────────────────────────
   release:
     runs-on: ubuntu-latest

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2026-09-03  Giuliano Pintori <pintori@link.it>
+
+        * Aggiunto alla pipeline il caricamento dell'SBOM su Dependency-Track.
+        Il nuovo job dependency-track-upload del workflow maven.yml scarica l'artifact prodotto dal job sbom gia' esistente e carica sbom/cyclonedx/bom.cdx.json sotto il progetto GovPay-Legacy del server interno, tramite il nuovo script script/sbom/upload-sbom-parent-required.sh.
+        L'upload copre i tag, master e le linee di manutenzione x.y.x (quindi anche 3.10.x), con la stessa condizione gia' usata dal job docker_dev. La versione registrata e' il nome del branch, cosi' master e 3.10.x convivono come versioni distinte dello stesso progetto; sui tag e' il tag ed e' marcata come latest. E' forzabile con FORCE_DTRACK_UPLOAD_JOB e disattivabile con DISABLE_DTRACK_UPLOAD_JOB, che ha la precedenza.
+        L'artifactId dell'aggregatore e' "bom": senza intervento il progetto sarebbe comparso su Dependency-Track con quel nome, quindi DTRACK_PROJECT_NAME lo forza a "govpay". Richiede il secret GOVPAY_DTRACK_API_KEY.
+
 2026-09-02  Giuliano Pintori <pintori@link.it>
 
         * Esposizione in lettura dei dati SEND nelle informazioni della pendenza (api-backoffice v1).

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@
         * Aggiunto alla pipeline il caricamento dell'SBOM su Dependency-Track.
         Il nuovo job dependency-track-upload del workflow maven.yml scarica l'artifact prodotto dal job sbom gia' esistente e carica sbom/cyclonedx/bom.cdx.json sotto il progetto GovPay-Legacy del server interno, tramite il nuovo script script/sbom/upload-sbom-parent-required.sh.
         L'upload copre i tag, master e le linee di manutenzione x.y.x (quindi anche 3.10.x), con la stessa condizione gia' usata dal job docker_dev. La versione registrata e' il nome del branch, cosi' master e 3.10.x convivono come versioni distinte dello stesso progetto; sui tag e' il tag ed e' marcata come latest. E' forzabile con FORCE_DTRACK_UPLOAD_JOB e disattivabile con DISABLE_DTRACK_UPLOAD_JOB, che ha la precedenza.
+        Aggiunto inoltre -DprojectType=application alla generazione dell'SBOM: il default del plugin CycloneDX e' "library", che avrebbe classificato su Dependency-Track come libreria un progetto che invece viene distribuito come applicazione.
         L'artifactId dell'aggregatore e' "bom": senza intervento il progetto sarebbe comparso su Dependency-Track con quel nome, quindi DTRACK_PROJECT_NAME lo forza a "govpay". Richiede il secret GOVPAY_DTRACK_API_KEY.
 
 2026-09-02  Giuliano Pintori <pintori@link.it>

--- a/script/sbom/upload-sbom-parent-required.sh
+++ b/script/sbom/upload-sbom-parent-required.sh
@@ -1,0 +1,275 @@
+#!/bin/bash
+# Upload SBOM su Dependency-Track sotto un progetto padre gia' esistente.
+#
+# Adattamento GovPay dello script GovDesk upload-sbom-dependency-track.sh.
+# Rispetto all'originale la gerarchia e' collassata: non ci sono i livelli
+# root/group/parent da creare, ma un solo progetto padre che DEVE gia'
+# esistere (da cui il nome "parent-required"). Nessun livello viene creato.
+#
+# Struttura attesa in Dependency-Track:
+#   <PARENT_PROJECT>              (es. "GovPay-Componente", senza versione - deve gia' esistere)
+#   |--- <PROJECT_NAME> <PROJECT_VERSION>
+#        (es. "govpay-common 2.0.4", "govpay-console-api main")
+#
+# Uso:
+#   ./upload-sbom-parent-required.sh <API_KEY> <FILE_SBOM> <PARENT_PROJECT>
+#
+# Nome e versione del progetto foglia non sono argomenti: vengono ricavati dai
+# metadati dell'SBOM (metadata.component), e sono sovrascrivibili via ambiente
+# per gestire i casi in cui la pipeline vuole imporre un valore diverso
+# (es. versione = nome del branch invece della versione Maven -SNAPSHOT).
+#
+# Variabili d'ambiente opzionali:
+#   DTRACK_URL           - URL di Dependency-Track (default: https://lab.link.it/dependency-track)
+#   DTRACK_PROJECT_NAME  - forza il nome del progetto foglia (default: da SBOM)
+#   DTRACK_VERSION       - forza la versione del progetto foglia (default: da SBOM)
+#   DTRACK_LATEST        - se "true" marca la versione come 'latest' (default: false)
+#   DTRACK_DEBUG         - se "true" stampa le risposte grezze delle API
+#
+# Permessi richiesti per l'API key:
+#   - VIEW_PORTFOLIO           (per la lookup del progetto padre)
+#   - PROJECT_CREATION_UPLOAD  (per creare la versione foglia)
+#   - BOM_UPLOAD               (per l'upload dell'SBOM)
+#   - PORTFOLIO_MANAGEMENT     (necessario solo se DTRACK_LATEST=true)
+
+set -u
+
+DTRACK_URL="${DTRACK_URL:-https://lab.link.it/dependency-track}"
+DTRACK_DEBUG="${DTRACK_DEBUG:-false}"
+LATEST="${DTRACK_LATEST:-false}"
+
+if [ $# -lt 3 ]; then
+    echo "Uso: $0 <API_KEY> <FILE_SBOM> <PARENT_PROJECT>"
+    echo ""
+    echo "Esempio:"
+    echo "  $0 odt_xxxxx sbom/cyclonedx/bom.cdx.json GovPay-Componente"
+    echo ""
+    echo "Nome e versione del progetto foglia sono ricavati dai metadati dell'SBOM."
+    echo "Per forzarli: DTRACK_PROJECT_NAME=... DTRACK_VERSION=... $0 ..."
+    exit 1
+fi
+
+API_KEY="$1"
+BOM_FILE="$2"
+PARENT_NAME="$3"
+
+if [ ! -f "$BOM_FILE" ]; then
+    echo "[ERROR] File SBOM non trovato: $BOM_FILE"
+    exit 1
+fi
+
+# --- Estrazione di nome e versione dai metadati dell'SBOM ---
+# I valori passati via ambiente hanno la precedenza.
+read_sbom_metadata() {
+    BOM_FILE="$BOM_FILE" python3 - <<'PY'
+import json, os, sys
+try:
+    with open(os.environ['BOM_FILE'], encoding='utf-8') as fh:
+        data = json.load(fh)
+except Exception as exc:
+    print(f"__ERROR__{exc}")
+    sys.exit(0)
+comp = (data.get('metadata') or {}).get('component') or {}
+print((comp.get('name') or '').strip())
+print((comp.get('version') or '').strip())
+PY
+}
+
+SBOM_META="$(read_sbom_metadata)"
+case "$SBOM_META" in
+    __ERROR__*)
+        echo "[ERROR] SBOM non leggibile: ${SBOM_META#__ERROR__}"
+        exit 1
+        ;;
+esac
+SBOM_NAME="$(echo "$SBOM_META" | sed -n '1p')"
+SBOM_VERSION="$(echo "$SBOM_META" | sed -n '2p')"
+
+PROJECT_NAME="${DTRACK_PROJECT_NAME:-$SBOM_NAME}"
+PROJECT_VERSION="${DTRACK_VERSION:-$SBOM_VERSION}"
+
+if [ -z "$PROJECT_NAME" ]; then
+    echo "[ERROR] Nome del progetto non determinabile: metadata.component.name assente nell'SBOM."
+    echo "[HINT]  Impostare DTRACK_PROJECT_NAME per forzarlo."
+    exit 1
+fi
+if [ -z "$PROJECT_VERSION" ]; then
+    echo "[ERROR] Versione del progetto non determinabile: metadata.component.version assente nell'SBOM."
+    echo "[HINT]  Impostare DTRACK_VERSION per forzarla."
+    exit 1
+fi
+
+echo "Dependency-Track: $DTRACK_URL"
+echo "Gerarchia: $PARENT_NAME / $PROJECT_NAME $PROJECT_VERSION"
+echo "SBOM: $BOM_FILE ($(wc -c < "$BOM_FILE") bytes)"
+if [ "$LATEST" = "true" ]; then
+    echo "Latest: SI (la versione verra' marcata come 'latest')"
+fi
+echo ""
+
+# URL-encode minimale per i nomi dei progetti (gestisce gli spazi).
+urlencode() {
+    python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$1"
+}
+
+# Stampa la response sull'errore per diagnostica.
+debug_response() {
+    if [ "$DTRACK_DEBUG" = "true" ]; then
+        echo "[DEBUG] Response: $1" >&2
+    fi
+}
+
+# Cerca nella lista JSON di progetti il primo con un dato nome e nessuna versione.
+# Il nome e' passato via ambiente, non interpolato nel sorgente Python, per non
+# rompersi su apici o caratteri speciali.
+# Riceve nome e path del file JSON. Il nome passa per ambiente, non
+# interpolato nel sorgente, per non rompersi su apici o caratteri speciali.
+filter_first_by_name_no_version() {
+    FILTER_NAME="$1" JSON_FILE="$2" python3 - <<'PY' 2>/dev/null
+import json, os
+name = os.environ['FILTER_NAME']
+try:
+    with open(os.environ['JSON_FILE'], encoding='utf-8') as fh:
+        data = json.load(fh)
+    # L'endpoint puo' restituire un array o un oggetto paginato {items:[...]}
+    if isinstance(data, dict) and 'items' in data:
+        data = data['items']
+    if not isinstance(data, list):
+        raise SystemExit
+    for p in data:
+        if p.get('name') == name and not p.get('version'):
+            print(p.get('uuid', ''))
+            break
+except Exception:
+    pass
+PY
+}
+
+# Elenca i nomi dei progetti senza versione restituiti dalla API, per capire
+# cosa vede effettivamente l'API key quando la lookup non trova nulla.
+# Riceve il path di un file JSON (non stdin: il programma Python arriva da
+# heredoc, quindi stdin non e' disponibile per i dati).
+list_candidate_names() {
+    JSON_FILE="$1" python3 - <<'PY' 2>/dev/null
+import json, os
+try:
+    with open(os.environ['JSON_FILE'], encoding='utf-8') as fh:
+        data = json.load(fh)
+    if isinstance(data, dict) and 'items' in data:
+        data = data['items']
+    if not isinstance(data, list):
+        raise SystemExit
+    for n in sorted({p.get('name', '') for p in data if not p.get('version')}):
+        if n:
+            print(f"         - {n}")
+except Exception:
+    pass
+PY
+}
+
+# Cerca il progetto padre per nome, fra quelli senza versione.
+# A differenza dell'originale controlla lo stato HTTP, per non confondere
+# "progetto assente" con "chiave non autorizzata" o "server irraggiungibile".
+# NB: assegna le globali LOOKUP_HTTP, LOOKUP_BODY e PARENT_UUID. Va invocata
+# direttamente e non in una command substitution, che girerebbe in una subshell
+# e perderebbe le assegnazioni.
+LOOKUP_BODY=""
+LOOKUP_HTTP=""
+PARENT_UUID=""
+LOOKUP_FILE="$(mktemp)"
+RESPONSE_FILE="$(mktemp)"
+trap 'rm -f "$LOOKUP_FILE" "$RESPONSE_FILE"' EXIT
+find_parent() {
+    local name="$1"
+    local enc resp
+    enc=$(urlencode "$name")
+    resp=$(curl -sk -H "X-Api-Key: $API_KEY" \
+        -w "\n__HTTP__:%{http_code}" \
+        "$DTRACK_URL/api/v1/project?name=$enc&excludeInactive=false")
+    LOOKUP_HTTP=$(printf '%s' "$resp" | sed -n 's/^__HTTP__://p' | tail -1)
+    LOOKUP_BODY=$(printf '%s' "$resp" | sed '$d')
+    debug_response "HTTP=$LOOKUP_HTTP body=$LOOKUP_BODY"
+    printf '%s' "$LOOKUP_BODY" > "$LOOKUP_FILE"
+    PARENT_UUID=$(filter_first_by_name_no_version "$name" "$LOOKUP_FILE")
+}
+
+# --- 1) Lookup del progetto padre (deve gia' esistere) ---
+echo "Ricerca progetto padre '$PARENT_NAME' ..."
+find_parent "$PARENT_NAME"
+
+if [ -z "$PARENT_UUID" ]; then
+    case "$LOOKUP_HTTP" in
+        000|"")
+            echo "[ERROR] Nessuna risposta da $DTRACK_URL (HTTP '$LOOKUP_HTTP')."
+            echo "[HINT]  Server irraggiungibile dal runner, oppure URL errato."
+            ;;
+        401)
+            echo "[ERROR] API key non valida o non autorizzata (HTTP 401)."
+            ;;
+        403)
+            echo "[ERROR] Permesso negato (HTTP 403): serve il permesso VIEW_PORTFOLIO."
+            ;;
+        200)
+            echo "[ERROR] Progetto padre '$PARENT_NAME' non trovato (HTTP 200)."
+            echo "[ERROR] La API key raggiunge il server ma non vede un progetto con"
+            echo "[ERROR] questo nome esatto e senza versione."
+            echo "[HINT]  Progetti senza versione visibili con questa chiave:"
+            if list_candidate_names "$LOOKUP_FILE" | grep -q .; then
+                list_candidate_names "$LOOKUP_FILE"
+            else
+                echo "         (nessuno: portfolio vuoto per questa chiave, probabile ACL)"
+            fi
+            echo "[HINT]  Verificare il nome esatto (maiuscole, trattini, spazi) e gli ACL."
+            ;;
+        *)
+            echo "[ERROR] Lookup fallita con HTTP $LOOKUP_HTTP."
+            echo "[ERROR] Body: $LOOKUP_BODY"
+            ;;
+    esac
+    exit 1
+fi
+echo "[OK] Progetto padre trovato: $PARENT_UUID"
+
+# --- 2) Upload SBOM come figlio del padre ---
+echo ""
+echo "Upload SBOM in corso ..."
+
+FORM_LATEST=()
+if [ "$LATEST" = "true" ]; then
+    FORM_LATEST=(-F "isLatest=true")
+fi
+
+HTTP_CODE=$(curl -sk -o "$RESPONSE_FILE" -w "%{http_code}" \
+    -X POST "$DTRACK_URL/api/v1/bom" \
+    -H "X-Api-Key: $API_KEY" \
+    -H "Content-Type: multipart/form-data" \
+    -F "autoCreate=true" \
+    -F "projectName=$PROJECT_NAME" \
+    -F "projectVersion=$PROJECT_VERSION" \
+    -F "parentUUID=$PARENT_UUID" \
+    "${FORM_LATEST[@]}" \
+    -F "bom=@$BOM_FILE")
+
+if [ "$HTTP_CODE" = "200" ]; then
+    echo "[OK] SBOM caricato con successo per $PROJECT_NAME $PROJECT_VERSION"
+    echo "     Figlio del progetto padre $PARENT_NAME ($PARENT_UUID)"
+    if [ "$LATEST" = "true" ]; then
+        echo "     Marcata come 'latest'"
+    fi
+elif [ "$HTTP_CODE" = "401" ]; then
+    echo "[ERROR] API key non valida o non autorizzata"
+    exit 1
+elif [ "$HTTP_CODE" = "403" ]; then
+    echo "[ERROR] Permesso negato. Verificare che l'API key abbia i permessi:"
+    echo "        VIEW_PORTFOLIO, PROJECT_CREATION_UPLOAD, BOM_UPLOAD"
+    if [ "$LATEST" = "true" ]; then
+        echo "[ERROR] Per DTRACK_LATEST=true serve anche PORTFOLIO_MANAGEMENT"
+    fi
+    cat "$RESPONSE_FILE" 2>/dev/null
+    exit 1
+else
+    echo "[ERROR] Upload fallito con HTTP $HTTP_CODE"
+    cat "$RESPONSE_FILE" 2>/dev/null
+    echo ""
+    exit 1
+fi


### PR DESCRIPTION
Completa il rollout dell'upload SBOM su Dependency-Track, gia' attivo sui componenti backend e frontend. Questo e' il progetto core, che va sotto il progetto padre **`GovPay-Legacy`**.

PR aperta su **`3.10.x`** come richiesto.

## Cosa cambia

**`.github/workflows/maven.yml`** — nuovo job `dependency-track-upload`, inserito dopo il job `sbom` gia' esistente. Qui, a differenza dei frontend, l'SBOM veniva gia' generato: serviva solo l'upload.

**`script/sbom/upload-sbom-parent-required.sh`** — copia identica dello script gia' su `main` di `govpay-common`.

## Due adattamenti specifici di questo repository

**Esecuzione su master e sulle linee di manutenzione.** L'upload deve avvenire sia su `master` sia su `3.10.x`. Ho usato la stessa condizione gia' adottata dal job `docker_dev` di questo workflow:

```
github.ref == 'refs/heads/master' || endsWith(github.ref, '.x')
```

cosi' la regola copre 3.10.x e ogni futura linea x.y.x senza doverla riaprire a ogni branch nuovo. La versione su Dependency-Track e' il nome del branch, quindi **`master` e `3.10.x` convivono come versioni distinte dello stesso progetto**. Sui tag la versione e' il tag ed e' marcata `latest`.

**Nome del progetto forzato.** L'artifactId dell'aggregatore e' letteralmente `bom`, quindi senza intervento il progetto sarebbe comparso su Dependency-Track come `bom 3.10.0-SNAPSHOT` — confondibile con `govpay-bom`. `DTRACK_PROJECT_NAME` lo forza a `govpay`.

## Verifiche

L'SBOM e' stato **generato davvero in locale** su questo progetto: 719 KB, **278 componenti**, `metadata.component` = `it.govpay:bom:3.10.0-SNAPSHOT` — da cui la necessita' dell'override sul nome, confermata dandolo in pasto allo script di upload.

La logica di versione e' stata verificata su tutti i casi: `master` -> `master`, `3.10.x` -> `3.10.x`, `3.9.x` -> `3.9.x`, un branch qualsiasi -> `dev`, tag `3.10.0` -> `3.10.0` con `latest=true`.

YAML del workflow validato e job agganciato a `needs: [sbom]`. Non e' stato eseguito un upload reale verso il server da questo repository.

## Prerequisito

Progetto padre **`GovPay-Legacy`** presente su Dependency-Track, senza versione. Il secret `GOVPAY_DTRACK_API_KEY` risulta gia' configurato.